### PR TITLE
Light Mode Text Visibility + Shared Note Text Length

### DIFF
--- a/components/Admin/AssistantAdminUI.tsx
+++ b/components/Admin/AssistantAdminUI.tsx
@@ -1561,7 +1561,7 @@ export const CreateAdminDialog: FC<CreateProps> = ({ createGroup, onClose, allEm
             }
             submitLabel={"Create Group"}
             content={
-                <>
+                <div className='text-black dark:text-white'>
                     {"You will be able to manage assistants and view key metrics related to user engagement and conversation."}
                             <div className="text-sm mb-4 text-black dark:text-neutral-200">{message}</div>
 
@@ -1595,7 +1595,7 @@ export const CreateAdminDialog: FC<CreateProps> = ({ createGroup, onClose, allEm
                                 </div>
                             </div>
                         
-                </>
+                </div>
             }
         />
     )

--- a/components/Share/SharedItemList.tsx
+++ b/components/Share/SharedItemList.tsx
@@ -249,11 +249,10 @@ const SharedItemsList: FC<{}> = () => {
                                 }}
                             >
                                 <IconShare size={18} className="ml-2 flex-shrink-0"/>
-                                <div className="truncate text-left text-[12.5px] leading-3 pr-1">
-                                    <div className="mb-1 text-gray-500">{new Date(item.sharedAt).toLocaleString()}</div>
+                                <div className="w-5/6 truncate text-left text-[12.5px] leading-3 pr-1">
+                                    <div className="mb-1 text-gray-500">{new Date(item.sharedAt).toLocaleString(undefined, {month: 'short', day: 'numeric',hour: 'numeric', minute: '2-digit',hour12: true})}</div>
                                     <div
-                                        className="relative max-w-5 truncate text-left text-[12.5px] leading-3 pr-1 "
-                                        style={{wordWrap: "break-word"}} // Added word wrap style
+                                        className="w-full relative text-left text-[12.5px] leading-4 truncate"
                                     >
                                         {item.note}
                                     </div>


### PR DESCRIPTION
3 Minor Text Formatting Fixes

1. **Assistant Admin UI**- Text Color 
Inside the Assistant Admin UI noticed that when using light mode some of the text remains white and is unreadable.
I just added a className to the div to adjust the text based on the users light/dark settings

2. **SharedItemsList**- Note
When looking at the shared items list, only one letter of the sharer's note appears so it is very difficult to tell which shared chat to import. I only modified some of the classNames so that more of the sharer's note will appear while maintaining that in the case the note is too long it will be truncated. 

3. **Share Date Formatting** updated the Date formatting to remove seconds and year:
Before: Mar 22, 2025 9:30:12 AM
After: Mar 22, 9:30 AM
