### PR TITLE
fix: prevent LaTeX processing in code blocks - resolve PowerShell variable interference

### DIFF
--- a/components/StandAloneAssistant/AssistantContentBlock.tsx
+++ b/components/StandAloneAssistant/AssistantContentBlock.tsx
@@ -37,19 +37,38 @@ const AssistantContentBlock: React.FC<AssistantContentBlockProps> = ({
 
   // Check if content contains LaTeX
   const hasLatex = useCallback((content: string) => {
-    return /\$\$.*?\$\$|\$[^$\n]+?\$|\\\[[\s\S]*?\\\]|\\\([\s\S]*?\\\)/.test(content);
+    // More precise LaTeX detection that avoids code blocks
+    const codeBlockRegex = /```[\s\S]*?```|`[^`]*`/g;
+    const contentWithoutCode = content.replace(codeBlockRegex, '');
+    return /\$\$[\s\S]*?\$\$|\\\[[\s\S]*?\\\]|\\\([\s\S]*?\\\)/.test(contentWithoutCode);
   }, []);
 
   // Memoized LaTeX processing function
   const processLatex = useCallback((content: string) => {
-    // Replace display math $$...$$ with placeholder
-    let processed = content.replace(/\$\$(.*?)\$\$/g, (match, latex) => {
-      return `<math-display>${latex}</math-display>`;
+    // Store code blocks temporarily to avoid processing them
+    const codeBlocks: string[] = [];
+    const codeBlockPlaceholders: string[] = [];
+    
+    // Replace code blocks with placeholders
+    let processed = content.replace(/```[\s\S]*?```/g, (match, offset) => {
+      const placeholder = `__CODE_BLOCK_${codeBlocks.length}__`;
+      codeBlocks.push(match);
+      codeBlockPlaceholders.push(placeholder);
+      return placeholder;
     });
     
-    // Replace inline math $...$ with placeholder  
-    processed = processed.replace(/\$([^$\n]+?)\$/g, (match, latex) => {
-      return `<math-inline>${latex}</math-inline>`;
+    // Replace inline code with placeholders
+    processed = processed.replace(/`[^`]*`/g, (match, offset) => {
+      const placeholder = `__INLINE_CODE_${codeBlocks.length}__`;
+      codeBlocks.push(match);
+      codeBlockPlaceholders.push(placeholder);
+      return placeholder;
+    });
+    
+    // Now process LaTeX only in non-code content
+    // Replace display math $$...$$ with placeholder
+    processed = processed.replace(/\$\$([\s\S]*?)\$\$/g, (match, latex) => {
+      return `<math-display>${latex}</math-display>`;
     });
     
     // Replace LaTeX display math \[ ... \] with placeholder
@@ -60,6 +79,11 @@ const AssistantContentBlock: React.FC<AssistantContentBlockProps> = ({
     // Replace LaTeX inline math \( ... \) with placeholder
     processed = processed.replace(/\\\(([\s\S]*?)\\\)/g, (match, latex) => {
       return `<math-inline>${latex}</math-inline>`;
+    });
+    
+    // Restore code blocks
+    codeBlockPlaceholders.forEach((placeholder, index) => {
+      processed = processed.replace(placeholder, codeBlocks[index]);
     });
     
     return processed;


### PR DESCRIPTION
* Update LaTeX detection to exclude content within code blocks (```...``` and `...`)
* Replace problematic $..$ inline math regex that incorrectly captured PowerShell variables
* Add code block preservation logic before LaTeX processing in:
  - components/Artifacts/ArtifactsContentBlock.tsx
  - components/Chat/ChatContentBlocks/ChatContentBlock.tsx
  - components/StandAloneAssistant/AssistantContentBlock.tsx
* Ensure PowerShell variables like $ModuleName display correctly without LaTeX interference
* Maintain support for proper LaTeX math expressions ($$..$$, \[..\], \(..\))

Fixes issue where code blocks containing $ symbols were incorrectly processed as LaTeX math