### PR TITLE
Download artifacts as docx and download code files inside of them in a zip.

### DIFF
--- a/components/Artifacts/Artifacts.tsx
+++ b/components/Artifacts/Artifacts.tsx
@@ -430,12 +430,12 @@ export const Artifacts: React.FC<Props> = ({artifactIndex}) => { //artifacts
         setShareWith([]);
     }
 
-    const handleDownloadArtifact = () => {
+    const handleDownloadArtifact = async () => {
         statsService.downloadArtifactEvent();
         setIsLoading('Downloading Artifact...');
         const artifact = selectArtifactList[versionIndex];
         const artifactContent = getArtifactContents();
-        downloadArtifacts(artifact.name.replace(/\s+/g, '_'), artifactContent, codeBlocks);
+        await downloadArtifacts(artifact.name.replace(/\s+/g, '_'), artifactContent, codeBlocks);
         setIsLoading('');
 
     }

--- a/utils/app/artifacts.ts
+++ b/utils/app/artifacts.ts
@@ -5,6 +5,9 @@ import { AttachedDocument } from "@/types/attacheddocument";
 import { addFile } from "@/services/fileService";
 import toast from "react-hot-toast";
 import { getFileMimeTypeFromLanguage } from "./fileTypeTranslations";
+import { convert, ConversionOptions } from "@/services/downloadService";
+import { LatestExportFormat } from "@/types/export";
+import { Conversation } from "@/types/chat";
 
 const downloadBlob = (blob: Blob, filename: string) => {
         const url = URL.createObjectURL(blob);
@@ -15,20 +18,90 @@ const downloadBlob = (blob: Blob, filename: string) => {
         URL.revokeObjectURL(url);
     };
 
-// download Artifact if extract the code blocks and make separate files for them, then put in a folder and save them all 
-export const downloadArtifacts = (artifactName: string, textContent: string, codeBlocks: CodeBlockDetails[]) => {
+// download Artifact if extract the code blocks and make separate files for them, then put in a folder and save them all
+export const downloadArtifacts = async (artifactName: string, textContent: string, codeBlocks: CodeBlockDetails[]) => {
     const files: { name: string; content: string; type: string }[] = [];
     const codeOnlyBlocks = codeBlocks.filter((block: CodeBlockDetails) => block.extension !== '.txt');
     let hasCodeBlocks = codeOnlyBlocks.length > 0;
 
 
     if (!hasCodeBlocks) {
-        // If only text and no code blocks, make it a .docx file
-        files.push({
-            name: `${artifactName}.docx`,
-            content: textContent,
-            type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-        });
+        // If only text and no code blocks, convert to proper .docx file using the conversion service. Otherwise, download the code blocks too (zip).
+        try {
+            console.log("Text content: ", textContent);
+            // Match the already existing format for conversation downloads here.
+            const exportedConversations: Conversation[] = [{
+                id: artifactName,
+                name: artifactName,
+                messages: [{
+                    role: 'assistant',
+                    content: textContent
+                }],
+                model: { id: 'artifact', name: 'Artifact' },
+                prompt: '',
+                temperature: 0.5,
+                folderId: '',
+                promptTemplate: null
+            } as Conversation];
+
+            const downloadData = {
+                version: 4,
+                history: exportedConversations,
+                folders: [],
+                prompts: [],
+            } as LatestExportFormat;
+
+            const conversionOptions: ConversionOptions = {
+                assistantHeader: "",
+                conversationHeader: "",
+                format: "docx",
+                messageHeader: "",
+                userHeader: "",
+                includeConversationName: false
+            };
+
+            const result = await convert(conversionOptions, downloadData);
+
+            if (result.success) {
+                const downloadUrl = result.data.url;
+
+                // Check if the file is ready and download it
+                const checkReady = async (url: string, triesLeft: number = 60): Promise<void> => {
+                    try {
+                        const response = await fetch(url);
+                        if (response.ok) {
+                            // Create a temporary anchor element to trigger download
+                            const blob = await response.blob();
+                            downloadBlob(blob, `${artifactName}.docx`);
+                        } else if (triesLeft > 0) {
+                            setTimeout(() => checkReady(url, triesLeft - 1), 1000);
+                        } else {
+                            console.error("Unable to download. Please check your Internet connection and try again.");
+                            // Fallback to plain text download
+                            const blob = new Blob([textContent], { type: 'text/plain' });
+                            downloadBlob(blob, `${artifactName}.txt`);
+                        }
+                    } catch (e) {
+                        console.error("Failed to reach the download service:", e);
+                        // Fallback to plain text download
+                        const blob = new Blob([textContent], { type: 'text/plain' });
+                        downloadBlob(blob, `${artifactName}.txt`);
+                    }
+                };
+
+                await checkReady(downloadUrl);
+            } else {
+                console.error("Failed to reach the download service.");
+                // Fallback to plain text download
+                const blob = new Blob([textContent], { type: 'text/plain' });
+                downloadBlob(blob, `${artifactName}.txt`);
+            }
+        } catch (error) {
+            console.error("Error during artifact download:", error);
+            // Fallback to plain text download
+            const blob = new Blob([textContent], { type: 'text/plain' });
+            downloadBlob(blob, `${artifactName}.txt`);
+        }
     } else {
         // Handle code blocks
         codeBlocks.forEach(block => {
@@ -43,24 +116,23 @@ export const downloadArtifacts = (artifactName: string, textContent: string, cod
                 type: mimeType
             });
         });
-    }
 
+        if (files.length === 1) {
+            // If there's only one file, download it directly
+            const file = files[0];
+            const blob = new Blob([file.content], { type: file.type });
+            downloadBlob(blob, file.name);
+        } else if (files.length > 1) {
+            // Create a proper ZIP file using JSZip
+            const zip = new JSZip();
+            files.forEach(file => {
+                zip.file(file.name, file.content);
+            });
 
-    if (files.length === 1) {
-        // If there's only one file, download it directly
-        const file = files[0];
-        const blob = new Blob([file.content], { type: file.type });
-        downloadBlob(blob, file.name);
-    } else if (files.length > 1) {
-        // Create a proper ZIP file using JSZip
-        const zip = new JSZip();
-        files.forEach(file => {
-            zip.file(file.name, file.content);
-        });
-
-        zip.generateAsync({ type: "blob" }).then((zipBlob) => {
-            downloadBlob(zipBlob, `${artifactName}.zip`);
-        });
+            zip.generateAsync({ type: "blob" }).then((zipBlob) => {
+                downloadBlob(zipBlob, `${artifactName}.zip`);
+            });
+        }
     }
 };
 


### PR DESCRIPTION
Main changes:

1) The existing code tried to format the .docx in the frontend without calling the download service, which didn't work. 
2) Made method async to call download service.
3) When just text exists, download as docx; otherwise, download as zip.

Screenshots:

<img width="943" height="775" alt="Screenshot 2025-12-08 at 3 39 36 PM" src="https://github.com/user-attachments/assets/92aa1311-d609-40d4-b2c0-0b3ad44857fe" />

<img width="676" height="393" alt="Screenshot 2025-12-08 at 3 39 54 PM" src="https://github.com/user-attachments/assets/8a7eba14-82aa-4d67-86c1-a07e84eaaab6" />

<img width="939" height="606" alt="Screenshot 2025-12-08 at 3 40 21 PM" src="https://github.com/user-attachments/assets/1c608461-edd2-4ca3-b1b0-4aee2509ec47" />
<img width="939" height="606" alt="Screenshot 2025-12-08 at 3 40 38 PM" src="https://github.com/user-attachments/assets/a23947b8-d3e9-41ed-93d9-fa6ecc456d72" />