### PR TITLE
Add Bedrock Knowledge Base support

### DIFF
--- a/components/Chat/ChatContentBlocks/ChatSource.tsx
+++ b/components/Chat/ChatContentBlocks/ChatSource.tsx
@@ -1,8 +1,9 @@
 import HomeContext from '@/pages/api/home/home.context';
 import { DataSource } from '@/types/chat';
 import { downloadDataSourceFile } from '@/utils/app/files';
+import { isBedrockKbDatasource, downloadBedrockKbFile, extractFileNameFromS3Uri, extractKbId } from '@/utils/app/bedrockKb';
 import { useSession } from 'next-auth/react';
-import React, { useContext,  } from "react";
+import React, { useContext, useState } from "react";
 import DOMPurify from 'dompurify';
 interface Props {
     source: any;
@@ -152,6 +153,7 @@ const ChatSourceBlock: React.FC<Props> = (
     {source, index, name}) => {
     const { data: session } = useSession();
     const user: any = session?.user;
+    const [kbDownloading, setKbDownloading] = useState(false);
 
     const { state: {}, setLoadingMessage
     } = useContext(HomeContext);
@@ -166,6 +168,18 @@ const ChatSourceBlock: React.FC<Props> = (
             setLoadingMessage("");
         }
     }
+
+    const handleBedrockKbDownload = async (knowledgeBaseId: string, s3Uri: string) => {
+        setKbDownloading(true);
+        try {
+            const success = await downloadBedrockKbFile(knowledgeBaseId, s3Uri);
+            if (!success) {
+                alert('Unable to download file. Please try again later.');
+            }
+        } finally {
+            setKbDownloading(false);
+        }
+    };
 
     
 
@@ -192,6 +206,35 @@ const ChatSourceBlock: React.FC<Props> = (
 
                 { source.url ? sanitizedUrl(source) :
                 <>
+                {isBedrockKbDatasource(source) ? (
+                    <>
+                    <div id="sourceName" className="dark:text-neutral-300 flex items-center gap-1">
+                        {source.name}
+                    </div>
+                    {source.locations && Array.isArray(source.locations) && source.locations.map((loc: any, locIdx: number) => {
+                        const s3Uri = loc.source;
+                        if (!s3Uri || !s3Uri.startsWith('s3://')) return null;
+                        const fileName = extractFileNameFromS3Uri(s3Uri);
+                        const kbId = extractKbId(source);
+                        return kbId ? (
+                            <button
+                                key={locIdx}
+                                className="mr-auto text-start text-[#5495ff] cursor-pointer hover:underline text-sm disabled:opacity-50"
+                                disabled={kbDownloading}
+                                title={`Download ${fileName}`}
+                                onClick={() => downloadBedrockKbFile(kbId, s3Uri).then(success => {
+                                    if (!success) alert('Unable to download file. Please try again later.');
+                                })}
+                            >
+                                {kbDownloading ? 'Downloading...' : fileName}
+                            </button>
+                        ) : (
+                            <div key={locIdx} className="text-sm dark:text-neutral-400">{fileName}</div>
+                        );
+                    })}
+                    </>
+                ) : (
+                <>
                 {source.name && (
                     (source.contentKey && !source.contentKey.includes("global/") &&  (source.contentKey.includes(user?.email) || source.contentKey.includes(user?.username) ||  source.groupId))  ? 
                         <button id="sourceName" className="mr-auto text-start text-[#5495ff] cursor-pointer hover:underline" title='Download File'
@@ -212,6 +255,8 @@ const ChatSourceBlock: React.FC<Props> = (
                             </React.Fragment>
                         ))}
                     </div>
+                )}
+                </>
                 )}
                 </>}
                 

--- a/components/Chat/FileList.tsx
+++ b/components/Chat/FileList.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useContext, useEffect, useState} from 'react';
-import { IconCircleX, IconCheck, IconWorld, IconSitemap, IconReload } from '@tabler/icons-react';
+import { IconCircleX, IconCheck, IconWorld, IconSitemap, IconReload, IconDatabase } from '@tabler/icons-react';
 import { AttachedDocument } from '@/types/attacheddocument';
 import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
@@ -36,6 +36,8 @@ const getIcon = (document:AttachedDocument) => {
             return <IconSitemap className="text-blue-500" size={18}/>
         case 'website/url':
             return <IconWorld className="text-blue-500" size={18}/>
+        case 'bedrock/knowledge-base':
+            return <IconDatabase className="text-purple-500" size={18}/>
         default:
             return null;
     }

--- a/components/DataSources/BedrockKBInput.tsx
+++ b/components/DataSources/BedrockKBInput.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { IconDatabase } from '@tabler/icons-react';
+import { createBedrockKbDatasource, validateKbId } from '@/utils/app/bedrockKb';
+import { AttachedDocument } from '@/types/attacheddocument';
+
+interface BedrockKBInputProps {
+    existingKbIds: string[];
+    onAdd: (datasource: AttachedDocument) => void;
+}
+
+export const BedrockKBInput: React.FC<BedrockKBInputProps> = ({ existingKbIds, onAdd }) => {
+    const [kbId, setKbId] = useState('');
+    const [displayName, setDisplayName] = useState('');
+    const [error, setError] = useState<string | null>(null);
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        setError(null);
+
+        const trimmedId = kbId.trim().toUpperCase();
+        const validation = validateKbId(trimmedId);
+        if (!validation.valid) {
+            setError(validation.error || 'Invalid Knowledge Base ID.');
+            return;
+        }
+
+        if (existingKbIds.includes(trimmedId)) {
+            setError('This Knowledge Base is already added.');
+            return;
+        }
+
+        const ds = createBedrockKbDatasource(trimmedId, displayName.trim() || undefined);
+        onAdd(ds);
+        setKbId('');
+        setDisplayName('');
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-2 mb-4">
+            <div className="flex items-center gap-2">
+                <input
+                    type="text"
+                    value={kbId}
+                    onChange={(e) => { setKbId(e.target.value); if (error) setError(null); }}
+                    placeholder="Knowledge Base ID (e.g. ABCDEFGHIJ)"
+                    className="flex-grow rounded-lg border border-neutral-500 px-4 py-2 text-neutral-900 shadow focus:outline-none dark:border-neutral-800 dark:border-opacity-50 dark:bg-[#40414F] dark:text-neutral-100"
+                />
+                <input
+                    type="text"
+                    value={displayName}
+                    onChange={(e) => setDisplayName(e.target.value)}
+                    placeholder="Display name (optional)"
+                    className="w-[200px] rounded-lg border border-neutral-500 px-4 py-2 text-neutral-900 shadow focus:outline-none dark:border-neutral-800 dark:border-opacity-50 dark:bg-[#40414F] dark:text-neutral-100"
+                />
+                <button
+                    type="submit"
+                    className="rounded-lg border border-neutral-500 px-4 py-2 text-neutral-900 hover:bg-neutral-100 focus:outline-none dark:border-neutral-800 dark:border-opacity-50 dark:bg-[#40414F] dark:text-neutral-100 dark:hover:bg-[#343541] flex items-center gap-2"
+                >
+                    <IconDatabase size={16} />
+                    Add KB
+                </button>
+            </div>
+            {error && (
+                <p className="text-red-500 text-sm ml-1">{error}</p>
+            )}
+        </form>
+    );
+};

--- a/components/Promptbar/components/AssistantModal.tsx
+++ b/components/Promptbar/components/AssistantModal.tsx
@@ -35,6 +35,8 @@ import ApiIntegrationsPanel from '@/components/AssistantApi/ApiIntegrationsPanel
 import { AssistantEmailEvents } from '@/components/Promptbar/components/AssistantModalComponents/AssistantEmailEvents';
 import { AssistantWorkflowDisplay } from './AssistantModalComponents/AssistantWorkflowDisplay';
 import { isWebsiteDs, WebsiteScanScheduler, WebsiteURLInput } from '@/components/DataSources/WebsiteURLInput';
+import { BedrockKBInput } from '@/components/DataSources/BedrockKBInput';
+import { isBedrockKbDatasource, extractKbId } from '@/utils/app/bedrockKb';
 import { Modal } from '@/components/ReusableComponents/Modal';
 import { ScheduledTaskButton } from '@/components/Agent/ScheduledTasks';
 import { deleteFile } from '@/services/fileService';
@@ -677,6 +679,7 @@ export const AssistantModal: FC<Props> = ({assistant, onCancel, onSave, onUpdate
           // console.log(dataSources.map((d: any)=> d.name));
 
             newAssistant.dataSources = dataSources.map(ds => {
+                if (isBedrockKbDatasource(ds)) return ds; // Bedrock KB datasources pass through as-is
                 if (isWebsiteDs(ds) && !ds.key) return ds; // signifies needs scraping
                 if (assistant.groupId) {
                     if (!ds.key) ds.key = ds.id;
@@ -1434,6 +1437,42 @@ export const AssistantModal: FC<Props> = ({assistant, onCancel, onSave, onUpdate
                                 onRescanScheduleChange={setDriveRescanSchedule}
                                 />
                             }
+
+                            {/* Bedrock Knowledge Base Section */}
+                            {featureFlags.bedrockKnowledgeBase && !disableEdit && (
+                                <>
+                                <div className="mt-2 mb-2 font-bold text-black dark:text-neutral-200">
+                                    {t('Attach Bedrock Knowledge Base')}
+                                </div>
+                                <BedrockKBInput
+                                    existingKbIds={dataSources
+                                        .filter(isBedrockKbDatasource)
+                                        .map(ds => extractKbId(ds))}
+                                    onAdd={(ds) => {
+                                        setDataSources([...dataSources, ds as any]);
+                                        setDocumentState({ ...documentState, [ds.id]: 100 });
+                                    }}
+                                />
+                                <FileList
+                                    documents={dataSources.filter((ds: AttachedDocument) =>
+                                        !(preexistingDocumentIds.includes(ds.id)) && isBedrockKbDatasource(ds)
+                                    )}
+                                    documentStates={documentState}
+                                    setDocuments={(docs) => {
+                                        const nonKb = dataSources.filter((ds: AttachedDocument) =>
+                                            !isBedrockKbDatasource(ds) || preexistingDocumentIds.includes(ds.id)
+                                        );
+                                        setDataSources([...docs, ...nonKb] as any[]);
+                                    }}
+                                    allowRemoval={!disableEdit}
+                                    onCancelUpload={(ds: AttachedDocument) => {
+                                        const updatedDocState = { ...documentState };
+                                        delete updatedDocState[ds.id];
+                                        setDocumentState(updatedDocState);
+                                    }}
+                                />
+                                </>
+                            )}
 
                             { definition.dataSources?.length > 0  &&
                              <div className="mt-4">

--- a/docs/bedrock-kb-frontend-integration.md
+++ b/docs/bedrock-kb-frontend-integration.md
@@ -1,0 +1,273 @@
+# Bedrock Knowledge Base — Frontend Integration Guide
+
+## Summary
+
+The backend now supports Bedrock Knowledge Base as a datasource type for assistants. Users provide a Knowledge Base ID, the backend validates it exists, stores it as a datasource, and queries it during chat. This document covers everything needed to update the UI.
+
+## New Datasource Type
+
+Type identifier: `bedrock/knowledge-base`
+ID format: `bedrock-kb://<knowledge-base-id>`
+
+A Bedrock KB datasource object looks like:
+
+```json
+{
+  "id": "bedrock-kb://ABCDEFGHIJ",
+  "name": "My Knowledge Base",
+  "type": "bedrock/knowledge-base",
+  "metadata": {
+    "knowledgeBaseId": "ABCDEFGHIJ",
+    "type": "bedrock/knowledge-base"
+  }
+}
+```
+
+The `knowledgeBaseId` is a 10-character alphanumeric string assigned by AWS Bedrock (e.g., `ABCDEFGHIJ`). Users get this from the AWS Bedrock console.
+
+## API Changes
+
+### POST `/assistant/create` — Create/Update Assistant
+
+The `dataSources` array now accepts Bedrock KB objects alongside existing file/website/drive datasources.
+
+Request payload (only the new datasource shown):
+
+```json
+{
+  "data": {
+    "name": "My Assistant",
+    "description": "Uses a Bedrock Knowledge Base",
+    "tags": ["knowledge-base"],
+    "instructions": "Answer questions using the knowledge base.",
+    "disclaimer": "",
+    "dataSources": [
+      {
+        "id": "bedrock-kb://ABCDEFGHIJ",
+        "name": "Product Documentation KB",
+        "type": "bedrock/knowledge-base",
+        "metadata": {
+          "knowledgeBaseId": "ABCDEFGHIJ",
+          "type": "bedrock/knowledge-base"
+        }
+      }
+    ]
+  }
+}
+```
+
+The backend will:
+1. Validate the KB ID exists via AWS API
+2. Return an error if the KB is not found: `{"success": false, "message": "Bedrock Knowledge Base not found: ABCDEFGHIJ"}`
+3. On success, store it in the assistant's `dataSources` array
+
+The response shape is unchanged:
+
+```json
+{
+  "success": true,
+  "message": "Assistant created successfully",
+  "data": {
+    "assistantId": "astp/...",
+    "id": "ast/...",
+    "version": 1,
+    "data_sources": [...]
+  }
+}
+```
+
+### Chat — No Changes Required
+
+Bedrock KB datasources are stored in the assistant's `dataSources` array and flow through the existing chat pipeline automatically. The backend handles separating them from standard datasources and querying the Bedrock KB during retrieval. No chat payload changes are needed from the frontend.
+
+## UI Requirements
+
+### Assistant Creation/Edit Form
+
+Add a new datasource input option for Bedrock Knowledge Base. The user needs to provide:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| Knowledge Base ID | Yes | The AWS Bedrock Knowledge Base ID (10-char alphanumeric) |
+| Display Name | No | A friendly name for the KB (shown in the datasource list) |
+
+Suggested UX:
+- Add a "Bedrock Knowledge Base" option to the datasource type selector (alongside file upload, website URL, drive integration)
+- When selected, show a text input for the Knowledge Base ID
+- Optional: a text input for a display name (defaults to the KB ID if not provided)
+- The KB ID input should accept a string like `ABCDEFGHIJ` — the frontend should construct the full datasource object with the `bedrock-kb://` prefix
+
+### Constructing the Datasource Object
+
+When the user adds a Bedrock KB datasource, build the object like this:
+
+```javascript
+function createBedrockKbDatasource(knowledgeBaseId, displayName) {
+  return {
+    id: `bedrock-kb://${knowledgeBaseId}`,
+    name: displayName || knowledgeBaseId,
+    type: "bedrock/knowledge-base",
+    metadata: {
+      knowledgeBaseId: knowledgeBaseId,
+      type: "bedrock/knowledge-base",
+    },
+  };
+}
+```
+
+This object gets added to the `dataSources` array in the create/update request alongside any other datasources.
+
+### Datasource List Display
+
+When rendering an assistant's datasources, detect Bedrock KB entries by:
+- `type === "bedrock/knowledge-base"`, or
+- `id` starts with `"bedrock-kb://"`
+
+Display them differently from file datasources:
+- Show a distinct icon (e.g., a database or cloud icon)
+- Show the display name and KB ID
+- No file size, token count, or upload date — these don't apply
+- No download action — there's no file to download
+
+### Editing an Existing Assistant
+
+When loading an existing assistant for editing, Bedrock KB datasources will appear in the `dataSources` array from the GET response. Parse them back into the form:
+
+```javascript
+function isBedrockKbDatasource(ds) {
+  return ds.type === "bedrock/knowledge-base" || ds.id?.startsWith("bedrock-kb://");
+}
+
+function extractKbId(ds) {
+  return ds.metadata?.knowledgeBaseId || ds.id?.replace("bedrock-kb://", "");
+}
+```
+
+### Validation
+
+Client-side validation before submitting:
+- KB ID should be non-empty
+- KB ID should be alphanumeric (Bedrock KB IDs are typically 10 uppercase alphanumeric characters)
+- Duplicate KB IDs in the same assistant should be prevented
+
+The backend performs the authoritative validation (checking the KB actually exists), so the frontend should handle the error response gracefully:
+
+```javascript
+// Example error handling
+if (!response.success && response.message.includes("Knowledge Base not found")) {
+  // Show error on the KB ID input: "Knowledge Base not found. Check the ID and try again."
+}
+```
+
+### Removing a Bedrock KB Datasource
+
+Same as removing any other datasource — just filter it out of the `dataSources` array before submitting the update.
+
+## Error States
+
+| Error | When | Suggested UI |
+|-------|------|-------------|
+| `Bedrock Knowledge Base not found: <id>` | KB ID doesn't exist in AWS | Inline error on the KB ID input field |
+| `Error validating Knowledge Base: <details>` | AWS API error (permissions, network) | Toast/banner: "Unable to validate Knowledge Base. Try again later." |
+
+## Mixing Datasource Types
+
+An assistant can have Bedrock KB datasources alongside file uploads, website URLs, and drive integrations. They all go in the same `dataSources` array. The backend handles routing queries to the right retrieval system at chat time.
+
+## Source Citations for Bedrock KB Results
+
+Bedrock KB retrieval results include source location metadata from the KB's backing S3 bucket (e.g., `s3://kb-data-bucket/documents/guide.pdf`). These are not directly accessible to users.
+
+Each RAG source object sent to the frontend for Bedrock KB results will have:
+
+```json
+{
+  "key": "bedrock-kb://ABCDEFGHIJ",
+  "contentKey": "bedrock-kb://ABCDEFGHIJ",
+  "name": "Product Documentation KB",
+  "type": "bedrock/knowledge-base",
+  "url": null,
+  "locations": [{"source": "s3://kb-data-bucket/documents/guide.pdf"}],
+  "content": "The retrieved text content..."
+}
+```
+
+### Display Recommendations
+
+- Show the source file name extracted from the S3 URI (e.g., `guide.pdf` from `s3://kb-data-bucket/documents/guide.pdf`)
+- If the `locations` array contains S3 URIs, render a download link that calls the new download endpoint
+- If download fails, fall back to showing the file name without a link
+
+### Downloading Source Files
+
+A new backend endpoint generates presigned download URLs for Bedrock KB source files. The backend validates that the requested file belongs to a bucket configured as a data source for the KB before generating the URL.
+
+```
+POST {API_BASE_URL}/bedrock-kb/download
+```
+
+Request:
+```json
+{
+  "data": {
+    "knowledgeBaseId": "ABCDEFGHIJ",
+    "s3Uri": "s3://kb-data-bucket/documents/guide.pdf"
+  }
+}
+```
+
+Success response:
+```json
+{
+  "success": true,
+  "downloadUrl": "https://kb-data-bucket.s3.amazonaws.com/documents/guide.pdf?X-Amz-...",
+  "fileName": "guide.pdf",
+  "message": "Download URL generated successfully"
+}
+```
+
+Error responses:
+```json
+{"success": false, "message": "S3 bucket 'wrong-bucket' is not a configured data source for KB ABCDEFGHIJ"}
+{"success": false, "message": "File not found: s3://kb-data-bucket/documents/missing.pdf"}
+```
+
+Example frontend helper:
+
+```javascript
+async function downloadBedrockKbFile(accessToken, knowledgeBaseId, s3Uri) {
+  const response = await fetch(`${API_BASE_URL}/bedrock-kb/download`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+      data: { knowledgeBaseId, s3Uri },
+    }),
+  });
+
+  const result = await response.json();
+  if (result.success && result.downloadUrl) {
+    // Open the presigned URL in a new tab or trigger download
+    window.open(result.downloadUrl, "_blank");
+  } else {
+    console.error("Download failed:", result.message);
+  }
+}
+```
+
+To extract the KB ID and S3 URI from a RAG source citation:
+
+```javascript
+function getDownloadInfoFromSource(source) {
+  if (!isBedrockKbDatasource(source)) return null;
+
+  const kbId = source.contentKey?.replace("bedrock-kb://", "") || extractKbId(source);
+  const s3Uri = source.locations?.[0]?.source;
+
+  if (!kbId || !s3Uri || !s3Uri.startsWith("s3://")) return null;
+
+  return { knowledgeBaseId: kbId, s3Uri };
+}
+```

--- a/utils/app/bedrockKb.ts
+++ b/utils/app/bedrockKb.ts
@@ -1,0 +1,89 @@
+import { AttachedDocument } from '@/types/attacheddocument';
+import { DataSource } from '@/types/chat';
+import { doRequestOp } from '@/services/doRequestOp';
+
+export const BEDROCK_KB_TYPE = 'bedrock/knowledge-base';
+export const BEDROCK_KB_PREFIX = 'bedrock-kb://';
+
+export const isBedrockKbDatasource = (ds: any): boolean => {
+    return ds.type === BEDROCK_KB_TYPE ||
+           ds.id?.startsWith(BEDROCK_KB_PREFIX) ||
+           ds.contentKey?.startsWith(BEDROCK_KB_PREFIX) ||
+           ds.key?.startsWith(BEDROCK_KB_PREFIX);
+};
+
+export const extractKbId = (ds: any): string => {
+    return ds.metadata?.knowledgeBaseId ||
+           ds.key?.replace(BEDROCK_KB_PREFIX, '') ||
+           ds.contentKey?.replace(BEDROCK_KB_PREFIX, '') ||
+           ds.id?.replace(BEDROCK_KB_PREFIX, '') || '';
+};
+
+export const createBedrockKbDatasource = (knowledgeBaseId: string, displayName?: string): AttachedDocument => {
+    return {
+        id: `${BEDROCK_KB_PREFIX}${knowledgeBaseId}`,
+        name: displayName || knowledgeBaseId,
+        raw: null,
+        type: BEDROCK_KB_TYPE,
+        data: null,
+        metadata: {
+            knowledgeBaseId,
+            type: BEDROCK_KB_TYPE,
+            totalTokens: 0,
+        },
+    };
+};
+
+/** Validates a Bedrock Knowledge Base ID (10-char uppercase alphanumeric) */
+export const validateKbId = (kbId: string): { valid: boolean; error?: string } => {
+    if (!kbId || kbId.trim().length === 0) {
+        return { valid: false, error: 'Knowledge Base ID is required.' };
+    }
+    if (!/^[A-Za-z0-9]+$/.test(kbId.trim())) {
+        return { valid: false, error: 'Knowledge Base ID must be alphanumeric.' };
+    }
+    return { valid: true };
+};
+
+/** Extract filename from an S3 URI (e.g., "guide.pdf" from "s3://bucket/docs/guide.pdf") */
+export const extractFileNameFromS3Uri = (s3Uri: string): string => {
+    if (!s3Uri) return 'Unknown file';
+    const parts = s3Uri.split('/');
+    return parts[parts.length - 1] || 'Unknown file';
+};
+
+/** Extract download info from a RAG source citation */
+export const getDownloadInfoFromSource = (source: any): { knowledgeBaseId: string; s3Uri: string } | null => {
+    if (!isBedrockKbDatasource(source)) return null;
+
+    const kbId = extractKbId(source);
+    const s3Uri = source.locations?.[0]?.source;
+
+    if (!kbId || !s3Uri || !s3Uri.startsWith('s3://')) return null;
+
+    return { knowledgeBaseId: kbId, s3Uri };
+};
+
+/** Download a source file from a Bedrock Knowledge Base via presigned URL */
+export const downloadBedrockKbFile = async (knowledgeBaseId: string, s3Uri: string): Promise<boolean> => {
+    try {
+        const result = await doRequestOp({
+            method: 'POST',
+            path: '/bedrock-kb',
+            op: '/download',
+            data: { knowledgeBaseId, s3Uri },
+            service: 'bedrock-kb',
+        });
+
+        if (result.success && result.downloadUrl) {
+            window.open(result.downloadUrl, '_blank');
+            return true;
+        } else {
+            console.error('Bedrock KB download failed:', result.message);
+            return false;
+        }
+    } catch (error) {
+        console.error('Error downloading Bedrock KB file:', error);
+        return false;
+    }
+};

--- a/utils/app/files.ts
+++ b/utils/app/files.ts
@@ -5,6 +5,7 @@ import toast from "react-hot-toast";
 import { capitalize } from "./data";
 import { embeddingDocumentStatus, clearEmbeddingStatusCache } from "@/services/adminService";
 import JSZip from "jszip";
+import { isBedrockKbDatasource } from "./bedrockKb";
 
 /**
  * Extract Microsoft Information Protection (MIP) sensitivity label from Office files.
@@ -132,6 +133,7 @@ export const extractSensitivityLabel = async (file: File): Promise<{ level: numb
 }
 
 export const downloadDataSourceFile = async (dataSource: DataSource, groupId: string | undefined = undefined) => {
+    if (isBedrockKbDatasource(dataSource)) return; // No file to download for Bedrock KB
     const response = await getFileDownloadUrl(dataSource.id, groupId); // support images too 
     if (!response.success) {
         alert("Error downloading file. Please try again.");
@@ -145,6 +147,10 @@ export const downloadDataSourceFile = async (dataSource: DataSource, groupId: st
 }
 
 export const deleteDatasourceFile = async (dataSource: DataSource, showToast: boolean = true) => {
+  if (isBedrockKbDatasource(dataSource)) {
+      // Bedrock KB datasources are references, not files — just remove from the array
+      return { success: true, fileName: dataSource.name || dataSource.id || 'Bedrock KB' };
+  }
   console.log("deleteDatasourceFile: ", dataSource)
   try {
       const response = await deleteFile(dataSource.id || 'none');


### PR DESCRIPTION
This adds frontend components to support Bedrock Knowledge Bases in Amplify Assistants.
- Adds modal to assistant creation/edit
- Support download links in data source references (validates the link belongs to the bucket linked to the KB)
- Is feature flagged
- Supported on an assistant with no KB, only a KB, or mixed KB and documents