### PR TITLE
Fix open redirect vulnerability in callbackUrl handling

### DIFF
--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -254,7 +254,9 @@ const Home = ({
     useEffect(() => {
         const callbackUrl = router.query.callbackUrl as string;
         if (session && callbackUrl) {
-            router.push(callbackUrl);
+            if (callbackUrl.startsWith('/') && !callbackUrl.startsWith('//')) {
+                router.push(callbackUrl);
+            }
         }
     }, [session, router]);
 


### PR DESCRIPTION
The callbackurl is open, meaning a malicious user could give a link looking trustworthy (vanderbilt.ai) and be able to redirect it to a phishing site, like a fake amplify site that would get them to input their credentials: 

https://www.vanderbilt.ai/?callbackUrl=https://evil.com
or
http://localhost:3000/?callbackUrl=https://evil.com

This redirects them to evil.com

<img width="1512" height="865" alt="image" src="https://github.com/user-attachments/assets/435cc016-06d2-4553-ae24-e48e0c19902f" />



This fix doesn't allow that ::

<img width="1512" height="865" alt="image" src="https://github.com/user-attachments/assets/96eb1368-96f6-4b1f-9707-3a74784c5095" />