### PR TITLE
feat: Add Skills UI for creating, managing, and selecting AI skills

### DIFF
--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -1820,8 +1820,9 @@ export const ChatInput = ({
                         }
 
                         {/* Skills Toggle - Select skills to use (only show if skills is enabled in FeaturePlugin) */}
-                        { featureFlags.skills && plugins?.some(p => p.id === PluginID.SKILLS) &&
+                        { featureFlags.skills && plugins?.some(p => p.id === PluginID.SKILLS) && chatEndpoint &&
                             <SkillsToggle
+                                chatEndpoint={chatEndpoint}
                                 selectedSkillIds={selectedSkillIds}
                                 onSelectionChange={setSelectedSkillIds}
                             />

--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -12,7 +12,8 @@ import {
     IconCheck,
     IconX,
     IconWorldSearch,
-    IconGripHorizontal
+    IconGripHorizontal,
+    IconSparkles
 } from '@tabler/icons-react';
 import SaveActionsModal from './SaveActionsModal';
 import {
@@ -82,6 +83,7 @@ import { AttachmentDisplay } from '@/components/Chat/AttachmentDisplay';
 import { useLargeTextManager } from '@/hooks/useLargeTextManager';
 import { useTextBlockEditor } from '@/hooks/useTextBlockEditor';
 import toast from 'react-hot-toast';
+import { SkillsToggle } from '@/components/Skills';
 
 
 
@@ -366,6 +368,10 @@ export const ChatInput = ({
     // Per-conversation web search toggle (independent from FeaturePlugin) - persists across messages
     const isWebSearchEnabledForConversation = selectedConversation?.data?.webSearchEnabled ?? false;
 
+    // Skills toggle state - stores skill IDs (persists in conversation data)
+    const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
+    const skillSelectionMode = selectedConversation?.data?.skillSelectionMode ?? 'auto';
+
     const promptListRef = useRef<HTMLUListElement | null>(null);
     const dataSourceSelectorRef = useRef<HTMLDivElement | null>(null);
     const actionSelectorRef = useRef<HTMLDivElement | null>(null);
@@ -571,7 +577,10 @@ export const ChatInput = ({
         let messageLabel = content || '';
         let messageData: any = {
             // Include per-message web search toggle state
-            enableWebSearch: isWebSearchEnabledForConversation
+            enableWebSearch: isWebSearchEnabledForConversation,
+            // Include selected skills
+            skills: selectedSkillIds,
+            skillSelectionMode: skillSelectionMode
         };
 
         if (largeTextBlocks.length > 0) {
@@ -1808,6 +1817,14 @@ export const ChatInput = ({
                         >
                             <IconWorldSearch size={20} />
                         </button>
+                        }
+
+                        {/* Skills Toggle - Select skills to use (only show if skills is enabled in FeaturePlugin) */}
+                        { featureFlags.skills && plugins?.some(p => p.id === PluginID.SKILLS) &&
+                            <SkillsToggle
+                                selectedSkillIds={selectedSkillIds}
+                                onSelectionChange={setSelectedSkillIds}
+                            />
                         }
 
                         <div className='flex flex-row gap-2'>

--- a/components/Chat/FeaturePluginSelector/PluginSelector.tsx
+++ b/components/Chat/FeaturePluginSelector/PluginSelector.tsx
@@ -39,6 +39,7 @@ export const PluginSelector: FC<Props> = ({
               if (plugin.id === PluginID.MEMORY && (!featureFlags.memory || !settingRef.current?.featureOptions.includeMemory)) return false;
               if (plugin.id === PluginID.MCP && !featureFlags.mcp) return false;
               if (plugin.id === PluginID.WEB_SEARCH && (!featureFlags.webSearch || !settingRef.current?.featureOptions.includeWebSearch)) return false;
+              if (plugin.id === PluginID.SKILLS && !featureFlags.skills) return false;
               return true; // Include the plugin in the list if no flags block it
           });
   }

--- a/components/Chatbar/components/ChatbarSettings.tsx
+++ b/components/Chatbar/components/ChatbarSettings.tsx
@@ -29,7 +29,7 @@ export const ChatbarSettings = () => {
     const initTaskRef = useRef<ScheduledTask | undefined>(undefined);
 
     const {
-        state: { featureFlags, syncingPrompts, canAddWebSearchApiKey, userDocumentationUrl },
+        state: { featureFlags, syncingPrompts, canAddWebSearchApiKey, userDocumentationUrl, chatEndpoint },
     } = useContext(HomeContext);
 
     let settingRef = useRef<Settings | null>(null);
@@ -153,10 +153,10 @@ export const ChatbarSettings = () => {
                     icon={<IconBrain size={18} />}
                     onClick={() => setIsSkillsLibraryOpen(true)}
                 />
-                {isSkillsLibraryOpen && (
+                {isSkillsLibraryOpen && chatEndpoint && (
                     <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
                         <div className="w-full max-w-5xl h-[85vh] bg-white dark:bg-[#343541] rounded-lg shadow-2xl overflow-hidden">
-                            <SkillsLibrary onClose={() => setIsSkillsLibraryOpen(false)} />
+                            <SkillsLibrary chatEndpoint={chatEndpoint} onClose={() => setIsSkillsLibraryOpen(false)} />
                         </div>
                         <button
                             onClick={() => setIsSkillsLibraryOpen(false)}

--- a/components/Chatbar/components/ChatbarSettings.tsx
+++ b/components/Chatbar/components/ChatbarSettings.tsx
@@ -1,4 +1,4 @@
-import { IconFileExport, IconPuzzle, IconDeviceSdCard, IconTools, IconAlarm, IconUsers, IconSearch, IconBook } from '@tabler/icons-react';
+import { IconFileExport, IconPuzzle, IconDeviceSdCard, IconTools, IconAlarm, IconUsers, IconSearch, IconBook, IconBrain } from '@tabler/icons-react';
 import { useContext, useEffect, useRef, useState, useCallback } from 'react';
 
 
@@ -17,6 +17,7 @@ import { PythonFunctionModal } from '@/components/Operations/PythonFunctionModal
 import { AssistantWorkflowBuilder } from '@/components/AssistantWorkflows/AssistantWorkflowBuilder';
 import { ScheduledTasks } from '@/components/Agent/ScheduledTasks';
 import { ScheduledTask } from '@/types/scheduledTasks';
+import { SkillsLibrary } from '@/components/Skills';
 
 export const ChatbarSettings = () => {
     const { t } = useTranslation('sidebar');
@@ -24,6 +25,7 @@ export const ChatbarSettings = () => {
     const [isPyFunctionApiOpen, setIsPyFunctionApiOpen] = useState(false);
     const [isWorkflowBuilderOpen, setIsWorkflowBuilderOpen] = useState(false);
     const [isScheduledTasksOpen, setIsScheduledTasksOpen] = useState(false);
+    const [isSkillsLibraryOpen, setIsSkillsLibraryOpen] = useState(false);
     const initTaskRef = useRef<ScheduledTask | undefined>(undefined);
 
     const {
@@ -140,6 +142,32 @@ export const ChatbarSettings = () => {
                     open={isMemoryDialogOpen}
                     onClose={() => setIsMemoryDialogOpen(false)}
                 />
+                </>
+            )}
+
+            {/* Skills Library */}
+            {featureFlags.skills && (
+                <>
+                <SidebarButton
+                    text={t('Skills')}
+                    icon={<IconBrain size={18} />}
+                    onClick={() => setIsSkillsLibraryOpen(true)}
+                />
+                {isSkillsLibraryOpen && (
+                    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
+                        <div className="w-full max-w-5xl h-[85vh] bg-white dark:bg-[#343541] rounded-lg shadow-2xl overflow-hidden">
+                            <SkillsLibrary onClose={() => setIsSkillsLibraryOpen(false)} />
+                        </div>
+                        <button
+                            onClick={() => setIsSkillsLibraryOpen(false)}
+                            className="absolute top-4 right-4 p-2 text-white bg-black/50 hover:bg-black/70 rounded-full"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    </div>
+                )}
                 </>
             )}
 

--- a/components/Promptbar/components/AssistantModal.tsx
+++ b/components/Promptbar/components/AssistantModal.tsx
@@ -164,7 +164,7 @@ export const AssistantModal: FC<Props> = ({assistant, onCancel, onSave, onUpdate
     const {t} = useTranslation('promptbar');
     const { data: session } = useSession();
     const userEmail = session?.user?.email ?? ''; // Kept as email to avoid breaking changes, updates in the backend handle username translation
-    const { state: { prompts, featureFlags, amplifyUsers, aiEmailDomain } , setLoadingMessage} = useContext(HomeContext);
+    const { state: { prompts, featureFlags, amplifyUsers, aiEmailDomain, chatEndpoint } , setLoadingMessage} = useContext(HomeContext);
 
     const isGroupAst = loc.includes("admin");
 
@@ -1593,9 +1593,10 @@ export const AssistantModal: FC<Props> = ({assistant, onCancel, onSave, onUpdate
                             </div>}
 
                             {/* Skills Section */}
-                            {featureFlags.skills && !disableEdit && (
+                            {featureFlags.skills && !disableEdit && chatEndpoint && (
                                 <div className="mb-4 mt-4">
                                     <SkillsSection
+                                        chatEndpoint={chatEndpoint}
                                         selectedSkills={selectedSkills}
                                         onSkillsChange={setSelectedSkills}
                                         skillSelectionMode={skillSelectionMode}

--- a/components/Promptbar/components/AssistantModal.tsx
+++ b/components/Promptbar/components/AssistantModal.tsx
@@ -44,6 +44,8 @@ import AssistantDriveDataSources, { cleanupRemovedDatasources, DriveRescanSchedu
 import { DriveFilesDataSources } from '@/types/integrations';
 import { determineWebsiteScanCron, manageScheduledTasks, updateScheduledTasks, determineDriveScanCron, AssistantScheduledTaskUses } from '@/utils/app/scheduledTasks';
 import { validateUrl } from '@/utils/app/data';
+import { SkillsSection } from '@/components/Skills';
+import { SkillReference, SkillSelectionMode } from '@/types/skill';
 
 
 interface Props {
@@ -302,6 +304,10 @@ export const AssistantModal: FC<Props> = ({assistant, onCancel, onSave, onUpdate
 
     const [availableAgentTools, setAvailableAgentTools] = useState<Record<string, any> | null>(null);
     const [builtInAgentTools, setBuiltInAgentTools] = useState<string[]>(definition.data?.builtInOperations ?? []);
+
+    // Skills state
+    const [selectedSkills, setSelectedSkills] = useState<SkillReference[]>(definition.data?.skills ?? []);
+    const [skillSelectionMode, setSkillSelectionMode] = useState<SkillSelectionMode>(definition.data?.skillSelectionMode ?? 'auto');
 
     const [availableOnRequest, setAvailableOnRequest] = useState(definition.data?.availableOnRequest || false);
     const [astIcon, setAstIcon] = useState<AttachedDocument | undefined>(definition.data?.astIcon);
@@ -828,7 +834,10 @@ export const AssistantModal: FC<Props> = ({assistant, onCancel, onSave, onUpdate
             newAssistant.data = {
                 ...newAssistant.data,
                 operations: combinedOps,
-                builtInOperations: builtInAgentTools
+                builtInOperations: builtInAgentTools,
+                // Skills
+                skills: selectedSkills.length > 0 ? selectedSkills : undefined,
+                skillSelectionMode: selectedSkills.length > 0 ? skillSelectionMode : undefined
             };
 
             if (apiOptions.IncludeApiInstr && apiInfo.some(api => !validateApiInfo(api))) {
@@ -1560,10 +1569,10 @@ export const AssistantModal: FC<Props> = ({assistant, onCancel, onSave, onUpdate
                             {enableEmailEvents &&
                             <div className="mb-4 mt-2 flex flex-col gap-2 mr-6">
                                 <label className=" text-[1.02rem]"> Email this assistant at: <span className='ml-2 text-blue-500'> {`${constructAstEventEmailAddress(emailEventTag ?? safeEmailEventTag(name), userEmail, aiEmailDomain)}`} </span></label>
-                            
-                                {!existingAllowedSenders ? <>Loading allowed senders...</> : 
-                                <ExpansionComponent title={"Manage authorized senders who can email this assistant"} 
-                                    closedWidget= { <IconMailFast size={22} />} 
+
+                                {!existingAllowedSenders ? <>Loading allowed senders...</> :
+                                <ExpansionComponent title={"Manage authorized senders who can email this assistant"}
+                                    closedWidget= { <IconMailFast size={22} />}
                                     content={
                                     <AddEmailWithAutoComplete
                                         id={`allowedSenders`}
@@ -1579,9 +1588,21 @@ export const AssistantModal: FC<Props> = ({assistant, onCancel, onSave, onUpdate
                                             setCurAllowedSenders(usernames);
                                         }}
                                         displayEmails={true}
-                                    />} 
+                                    />}
                                 />}
                             </div>}
+
+                            {/* Skills Section */}
+                            {featureFlags.skills && !disableEdit && (
+                                <div className="mb-4 mt-4">
+                                    <SkillsSection
+                                        selectedSkills={selectedSkills}
+                                        onSkillsChange={setSelectedSkills}
+                                        skillSelectionMode={skillSelectionMode}
+                                        onModeChange={setSkillSelectionMode}
+                                    />
+                                </div>
+                            )}
 
                             <br></br>
 

--- a/components/Skills/SkillEditor.tsx
+++ b/components/Skills/SkillEditor.tsx
@@ -1,0 +1,327 @@
+import React, { useState, useEffect, FC } from 'react';
+import {
+    IconCode,
+    IconTags,
+    IconBolt,
+    IconEye,
+    IconEyeOff,
+    IconX,
+    IconDeviceFloppy
+} from '@tabler/icons-react';
+import {
+    Skill,
+    CreateSkillData,
+    UpdateSkillData,
+    DEFAULT_SKILL_TEMPLATE,
+    SKILL_CATEGORIES
+} from '@/types/skill';
+import { parseSkillFrontmatter } from '@/services/skillsService';
+
+interface SkillEditorProps {
+    skill?: Skill;
+    onSave: (skillData: CreateSkillData | UpdateSkillData) => void;
+    onCancel: () => void;
+    isLoading?: boolean;
+}
+
+export const SkillEditor: FC<SkillEditorProps> = ({
+    skill,
+    onSave,
+    onCancel,
+    isLoading = false
+}) => {
+    const [content, setContent] = useState(skill?.content || DEFAULT_SKILL_TEMPLATE);
+    const [name, setName] = useState(skill?.name || '');
+    const [description, setDescription] = useState(skill?.description || '');
+    const [tags, setTags] = useState<string[]>(skill?.tags || []);
+    const [triggerPhrases, setTriggerPhrases] = useState<string[]>(skill?.triggerPhrases || []);
+    const [priority, setPriority] = useState(skill?.priority || 5);
+    const [category, setCategory] = useState(skill?.category || 'general');
+    const [isPublic, setIsPublic] = useState(skill?.isPublic || false);
+    const [showPreview, setShowPreview] = useState(false);
+    const [tagInput, setTagInput] = useState('');
+    const [triggerInput, setTriggerInput] = useState('');
+
+    // Parse frontmatter when content changes
+    useEffect(() => {
+        const parsed = parseSkillFrontmatter(content);
+        if (parsed.name && !name) setName(parsed.name);
+        if (parsed.description && !description) setDescription(parsed.description);
+        if (parsed.tags?.length && !tags.length) setTags(parsed.tags);
+        if (parsed.triggerPhrases?.length && !triggerPhrases.length) setTriggerPhrases(parsed.triggerPhrases);
+        if (parsed.priority) setPriority(parsed.priority);
+        if (parsed.category) setCategory(parsed.category);
+    }, []);
+
+    const handleSave = () => {
+        const skillData: CreateSkillData | UpdateSkillData = {
+            content,
+            name: name || 'Untitled Skill',
+            description,
+            tags,
+            triggerPhrases,
+            priority,
+            category,
+            isPublic
+        };
+        onSave(skillData);
+    };
+
+    const addTag = () => {
+        if (tagInput.trim() && !tags.includes(tagInput.trim())) {
+            setTags([...tags, tagInput.trim()]);
+            setTagInput('');
+        }
+    };
+
+    const removeTag = (tagToRemove: string) => {
+        setTags(tags.filter(t => t !== tagToRemove));
+    };
+
+    const addTrigger = () => {
+        if (triggerInput.trim() && !triggerPhrases.includes(triggerInput.trim())) {
+            setTriggerPhrases([...triggerPhrases, triggerInput.trim()]);
+            setTriggerInput('');
+        }
+    };
+
+    const removeTrigger = (triggerToRemove: string) => {
+        setTriggerPhrases(triggerPhrases.filter(t => t !== triggerToRemove));
+    };
+
+    return (
+        <div className="flex flex-col h-full bg-white dark:bg-[#343541] rounded-lg shadow-lg overflow-hidden">
+            {/* Header */}
+            <div className="flex items-center justify-between p-4 border-b border-neutral-200 dark:border-neutral-600">
+                <h2 className="text-xl font-semibold text-neutral-800 dark:text-neutral-200">
+                    {skill ? 'Edit Skill' : 'Create New Skill'}
+                </h2>
+                <div className="flex gap-2">
+                    <button
+                        onClick={() => setShowPreview(!showPreview)}
+                        className="p-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded text-neutral-600 dark:text-neutral-400"
+                        title={showPreview ? "Hide Preview" : "Show Preview"}
+                    >
+                        {showPreview ? <IconEyeOff size={20} /> : <IconEye size={20} />}
+                    </button>
+                    <button
+                        onClick={onCancel}
+                        className="p-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded text-neutral-600 dark:text-neutral-400"
+                        title="Close"
+                    >
+                        <IconX size={20} />
+                    </button>
+                </div>
+            </div>
+
+            {/* Scrollable Content Area */}
+            <div className="flex-1 overflow-y-auto">
+                {/* Metadata Section */}
+                <div className="p-4 border-b border-neutral-200 dark:border-neutral-600 space-y-4">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+                                Name *
+                            </label>
+                            <input
+                                type="text"
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                                className="w-full p-2 border border-neutral-300 dark:border-neutral-600 rounded bg-white dark:bg-[#40414f] text-neutral-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                placeholder="Skill name"
+                            />
+                        </div>
+                        <div className="flex gap-4">
+                            <div className="flex-1">
+                                <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+                                    Priority (1-10)
+                                </label>
+                                <input
+                                    type="number"
+                                    min={1}
+                                    max={10}
+                                    value={priority}
+                                    onChange={(e) => setPriority(Math.min(10, Math.max(1, parseInt(e.target.value) || 5)))}
+                                    className="w-full p-2 border border-neutral-300 dark:border-neutral-600 rounded bg-white dark:bg-[#40414f] text-neutral-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                />
+                            </div>
+                            <div className="flex-1">
+                                <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+                                    Category
+                                </label>
+                                <select
+                                    value={category}
+                                    onChange={(e) => setCategory(e.target.value)}
+                                    className="w-full p-2 border border-neutral-300 dark:border-neutral-600 rounded bg-white dark:bg-[#40414f] text-neutral-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                >
+                                    {SKILL_CATEGORIES.map(cat => (
+                                        <option key={cat.id} value={cat.id}>{cat.name}</option>
+                                    ))}
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+                            Description
+                        </label>
+                        <input
+                            type="text"
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            className="w-full p-2 border border-neutral-300 dark:border-neutral-600 rounded bg-white dark:bg-[#40414f] text-neutral-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                            placeholder="Brief description of what this skill does"
+                        />
+                    </div>
+
+                    {/* Tags */}
+                    <div>
+                        <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+                            <IconTags size={16} className="inline mr-1" />
+                            Tags
+                        </label>
+                        <div className="flex gap-2 mb-2">
+                            <input
+                                type="text"
+                                value={tagInput}
+                                onChange={(e) => setTagInput(e.target.value)}
+                                onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), addTag())}
+                                className="flex-1 p-2 border border-neutral-300 dark:border-neutral-600 rounded bg-white dark:bg-[#40414f] text-neutral-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                placeholder="Add a tag and press Enter"
+                            />
+                            <button
+                                onClick={addTag}
+                                className="px-3 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+                            >
+                                Add
+                            </button>
+                        </div>
+                        <div className="flex flex-wrap gap-1">
+                            {tags.map(tag => (
+                                <span
+                                    key={tag}
+                                    className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 rounded text-sm"
+                                >
+                                    {tag}
+                                    <button
+                                        onClick={() => removeTag(tag)}
+                                        className="hover:text-blue-900 dark:hover:text-blue-100"
+                                    >
+                                        <IconX size={14} />
+                                    </button>
+                                </span>
+                            ))}
+                        </div>
+                    </div>
+
+                    {/* Trigger Phrases */}
+                    <div>
+                        <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+                            <IconBolt size={16} className="inline mr-1" />
+                            Trigger Phrases
+                        </label>
+                        <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-2">
+                            When these phrases appear in a message, this skill may be auto-selected
+                        </p>
+                        <div className="flex gap-2 mb-2">
+                            <input
+                                type="text"
+                                value={triggerInput}
+                                onChange={(e) => setTriggerInput(e.target.value)}
+                                onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), addTrigger())}
+                                className="flex-1 p-2 border border-neutral-300 dark:border-neutral-600 rounded bg-white dark:bg-[#40414f] text-neutral-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                placeholder="e.g., 'review my code' or 'write a blog post'"
+                            />
+                            <button
+                                onClick={addTrigger}
+                                className="px-3 py-2 bg-purple-500 text-white rounded hover:bg-purple-600"
+                            >
+                                Add
+                            </button>
+                        </div>
+                        <div className="flex flex-wrap gap-1">
+                            {triggerPhrases.map(phrase => (
+                                <span
+                                    key={phrase}
+                                    className="inline-flex items-center gap-1 px-2 py-1 bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-300 rounded text-sm"
+                                >
+                                    "{phrase}"
+                                    <button
+                                        onClick={() => removeTrigger(phrase)}
+                                        className="hover:text-purple-900 dark:hover:text-purple-100"
+                                    >
+                                        <IconX size={14} />
+                                    </button>
+                                </span>
+                            ))}
+                        </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <input
+                            type="checkbox"
+                            id="isPublic"
+                            checked={isPublic}
+                            onChange={(e) => setIsPublic(e.target.checked)}
+                            className="rounded border-neutral-300 dark:border-neutral-600 text-blue-500 focus:ring-blue-500"
+                        />
+                        <label htmlFor="isPublic" className="text-sm text-neutral-700 dark:text-neutral-300">
+                            Make this skill publicly discoverable
+                        </label>
+                    </div>
+                </div>
+
+                {/* Editor Section */}
+                <div className={`flex ${showPreview ? 'flex-row' : 'flex-col'} flex-1 min-h-[300px]`}>
+                    <div className={`${showPreview ? 'w-1/2' : 'w-full'} p-4`}>
+                        <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+                            <IconCode size={16} className="inline mr-1" />
+                            Skill Content (Markdown)
+                        </label>
+                        <textarea
+                            value={content}
+                            onChange={(e) => setContent(e.target.value)}
+                            className="w-full h-[400px] p-3 font-mono text-sm border border-neutral-300 dark:border-neutral-600 rounded bg-white dark:bg-[#40414f] text-neutral-900 dark:text-white resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                            placeholder="Enter your skill markdown content..."
+                        />
+                    </div>
+
+                    {showPreview && (
+                        <div className="w-1/2 p-4 border-l border-neutral-200 dark:border-neutral-600 overflow-auto bg-neutral-50 dark:bg-[#2a2b32]">
+                            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+                                Preview
+                            </label>
+                            <div className="prose dark:prose-invert max-w-none text-sm">
+                                <pre className="whitespace-pre-wrap bg-white dark:bg-[#40414f] p-3 rounded overflow-auto">
+                                    {content}
+                                </pre>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {/* Footer */}
+            <div className="flex justify-end gap-3 p-4 border-t border-neutral-200 dark:border-neutral-600 bg-neutral-50 dark:bg-[#2a2b32]">
+                <button
+                    onClick={onCancel}
+                    className="px-4 py-2 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded"
+                    disabled={isLoading}
+                >
+                    Cancel
+                </button>
+                <button
+                    onClick={handleSave}
+                    disabled={isLoading || !name.trim()}
+                    className="px-4 py-2 bg-blue-600 text-white hover:bg-blue-700 rounded flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                    <IconDeviceFloppy size={18} />
+                    {isLoading ? 'Saving...' : (skill ? 'Save Changes' : 'Create Skill')}
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default SkillEditor;

--- a/components/Skills/SkillEditor.tsx
+++ b/components/Skills/SkillEditor.tsx
@@ -90,7 +90,7 @@ export const SkillEditor: FC<SkillEditorProps> = ({
     };
 
     return (
-        <div className="flex flex-col h-full bg-white dark:bg-[#343541] rounded-lg shadow-lg overflow-hidden">
+        <div className="flex flex-col min-h-full bg-white dark:bg-[#343541] rounded-lg shadow-lg">
             {/* Header */}
             <div className="flex items-center justify-between p-4 border-b border-neutral-200 dark:border-neutral-600">
                 <h2 className="text-xl font-semibold text-neutral-800 dark:text-neutral-200">
@@ -115,7 +115,7 @@ export const SkillEditor: FC<SkillEditorProps> = ({
             </div>
 
             {/* Scrollable Content Area */}
-            <div className="flex-1 overflow-y-auto">
+            <div className="flex-1 overflow-y-auto min-h-0">
                 {/* Metadata Section */}
                 <div className="p-4 border-b border-neutral-200 dark:border-neutral-600 space-y-4">
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/components/Skills/SkillEditor.tsx
+++ b/components/Skills/SkillEditor.tsx
@@ -90,9 +90,9 @@ export const SkillEditor: FC<SkillEditorProps> = ({
     };
 
     return (
-        <div className="flex flex-col min-h-full bg-white dark:bg-[#343541] rounded-lg shadow-lg">
+        <div className="flex flex-col h-full max-h-full bg-white dark:bg-[#343541] rounded-lg shadow-lg overflow-hidden">
             {/* Header */}
-            <div className="flex items-center justify-between p-4 border-b border-neutral-200 dark:border-neutral-600">
+            <div className="flex-shrink-0 flex items-center justify-between p-4 border-b border-neutral-200 dark:border-neutral-600">
                 <h2 className="text-xl font-semibold text-neutral-800 dark:text-neutral-200">
                     {skill ? 'Edit Skill' : 'Create New Skill'}
                 </h2>
@@ -303,7 +303,7 @@ export const SkillEditor: FC<SkillEditorProps> = ({
             </div>
 
             {/* Footer */}
-            <div className="flex justify-end gap-3 p-4 border-t border-neutral-200 dark:border-neutral-600 bg-neutral-50 dark:bg-[#2a2b32]">
+            <div className="flex-shrink-0 flex justify-end gap-3 p-4 border-t border-neutral-200 dark:border-neutral-600 bg-neutral-50 dark:bg-[#2a2b32]">
                 <button
                     onClick={onCancel}
                     className="px-4 py-2 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded"

--- a/components/Skills/SkillSelector.tsx
+++ b/components/Skills/SkillSelector.tsx
@@ -12,6 +12,7 @@ import { Skill, SKILL_CATEGORIES } from '@/types/skill';
 import { getUserSkills } from '@/services/skillsService';
 
 interface SkillSelectorProps {
+    chatEndpoint: string;
     selectedSkillIds: string[];
     onSelectionChange: (skillIds: string[]) => void;
     onCreateNew?: () => void;
@@ -21,6 +22,7 @@ interface SkillSelectorProps {
 }
 
 export const SkillSelector: FC<SkillSelectorProps> = ({
+    chatEndpoint,
     selectedSkillIds,
     onSelectionChange,
     onCreateNew,
@@ -40,7 +42,7 @@ export const SkillSelector: FC<SkillSelectorProps> = ({
         setError(null);
 
         try {
-            const response = await getUserSkills(true);
+            const response = await getUserSkills(chatEndpoint, true);
             if (response.success && response.data) {
                 setSkills(response.data);
             } else {
@@ -52,7 +54,7 @@ export const SkillSelector: FC<SkillSelectorProps> = ({
         } finally {
             setLoading(false);
         }
-    }, []);
+    }, [chatEndpoint]);
 
     useEffect(() => {
         loadSkills();

--- a/components/Skills/SkillSelector.tsx
+++ b/components/Skills/SkillSelector.tsx
@@ -1,0 +1,307 @@
+import React, { useState, useEffect, FC, useCallback } from 'react';
+import {
+    IconBrain,
+    IconPlus,
+    IconCheck,
+    IconSearch,
+    IconRefresh,
+    IconChevronDown,
+    IconChevronUp
+} from '@tabler/icons-react';
+import { Skill, SKILL_CATEGORIES } from '@/types/skill';
+import { getUserSkills } from '@/services/skillsService';
+
+interface SkillSelectorProps {
+    selectedSkillIds: string[];
+    onSelectionChange: (skillIds: string[]) => void;
+    onCreateNew?: () => void;
+    mode?: 'toggle' | 'select'; // toggle for conversation, select for assistant
+    compact?: boolean;
+    maxSelections?: number;
+}
+
+export const SkillSelector: FC<SkillSelectorProps> = ({
+    selectedSkillIds,
+    onSelectionChange,
+    onCreateNew,
+    mode = 'toggle',
+    compact = false,
+    maxSelections = 5
+}) => {
+    const [skills, setSkills] = useState<Skill[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [filterCategory, setFilterCategory] = useState<string | null>(null);
+    const [expanded, setExpanded] = useState(!compact);
+
+    const loadSkills = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+
+        try {
+            const response = await getUserSkills(true);
+            if (response.success && response.data) {
+                setSkills(response.data);
+            } else {
+                setError(response.message || 'Failed to load skills');
+            }
+        } catch (err) {
+            console.error('Failed to load skills:', err);
+            setError('Failed to load skills');
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        loadSkills();
+    }, [loadSkills]);
+
+    const allCategories = [...new Set(skills.map(s => s.category).filter(Boolean))];
+
+    const filteredSkills = skills.filter(skill => {
+        const matchesSearch = !searchQuery ||
+            skill.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+            skill.description?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+            skill.tags?.some(t => t.toLowerCase().includes(searchQuery.toLowerCase()));
+        const matchesCategory = !filterCategory || skill.category === filterCategory;
+        return matchesSearch && matchesCategory && skill.isEnabled;
+    });
+
+    const toggleSkill = (skillId: string) => {
+        if (selectedSkillIds.includes(skillId)) {
+            onSelectionChange(selectedSkillIds.filter(id => id !== skillId));
+        } else {
+            if (selectedSkillIds.length >= maxSelections) {
+                // Remove the oldest selection when max is reached
+                onSelectionChange([...selectedSkillIds.slice(1), skillId]);
+            } else {
+                onSelectionChange([...selectedSkillIds, skillId]);
+            }
+        }
+    };
+
+    const getCategoryName = (categoryId: string) => {
+        return SKILL_CATEGORIES.find(c => c.id === categoryId)?.name || categoryId;
+    };
+
+    if (compact && !expanded) {
+        return (
+            <button
+                onClick={() => setExpanded(true)}
+                className="flex items-center gap-2 px-3 py-2 bg-neutral-100 dark:bg-neutral-700 hover:bg-neutral-200 dark:hover:bg-neutral-600 rounded-lg text-sm text-neutral-700 dark:text-neutral-300"
+            >
+                <IconBrain size={18} className="text-purple-500" />
+                <span>Skills</span>
+                {selectedSkillIds.length > 0 && (
+                    <span className="px-1.5 py-0.5 bg-purple-500 text-white rounded-full text-xs">
+                        {selectedSkillIds.length}
+                    </span>
+                )}
+                <IconChevronDown size={16} />
+            </button>
+        );
+    }
+
+    return (
+        <div className="bg-white dark:bg-[#343541] rounded-lg shadow-lg border border-neutral-200 dark:border-neutral-600 overflow-hidden">
+            {/* Header */}
+            <div className="p-3 border-b border-neutral-200 dark:border-neutral-600">
+                <div className="flex items-center justify-between mb-2">
+                    <div className="flex items-center gap-2">
+                        <IconBrain size={20} className="text-purple-500" />
+                        <span className="font-medium text-neutral-800 dark:text-neutral-200">Skills</span>
+                        {selectedSkillIds.length > 0 && (
+                            <span className="px-2 py-0.5 bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-300 rounded-full text-xs">
+                                {selectedSkillIds.length} selected
+                            </span>
+                        )}
+                    </div>
+                    <div className="flex items-center gap-1">
+                        <button
+                            onClick={loadSkills}
+                            className="p-1 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded text-neutral-500 dark:text-neutral-400"
+                            title="Refresh skills"
+                            disabled={loading}
+                        >
+                            <IconRefresh size={16} className={loading ? 'animate-spin' : ''} />
+                        </button>
+                        {onCreateNew && (
+                            <button
+                                onClick={onCreateNew}
+                                className="p-1 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded text-neutral-500 dark:text-neutral-400"
+                                title="Create new skill"
+                            >
+                                <IconPlus size={16} />
+                            </button>
+                        )}
+                        {compact && (
+                            <button
+                                onClick={() => setExpanded(false)}
+                                className="p-1 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded text-neutral-500 dark:text-neutral-400"
+                                title="Collapse"
+                            >
+                                <IconChevronUp size={16} />
+                            </button>
+                        )}
+                    </div>
+                </div>
+
+                {/* Search */}
+                <div className="relative mb-2">
+                    <IconSearch size={16} className="absolute left-2 top-1/2 -translate-y-1/2 text-neutral-400" />
+                    <input
+                        type="text"
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        placeholder="Search skills..."
+                        className="w-full pl-8 pr-3 py-1.5 text-sm border border-neutral-300 dark:border-neutral-600 rounded bg-white dark:bg-[#40414f] text-neutral-900 dark:text-white focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                    />
+                </div>
+
+                {/* Category filters */}
+                {allCategories.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                        <button
+                            onClick={() => setFilterCategory(null)}
+                            className={`px-2 py-0.5 text-xs rounded transition-colors ${
+                                !filterCategory
+                                    ? 'bg-purple-500 text-white'
+                                    : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-600'
+                            }`}
+                        >
+                            All
+                        </button>
+                        {allCategories.slice(0, 5).map(cat => (
+                            <button
+                                key={cat}
+                                onClick={() => setFilterCategory(cat === filterCategory ? null : cat)}
+                                className={`px-2 py-0.5 text-xs rounded transition-colors ${
+                                    filterCategory === cat
+                                        ? 'bg-purple-500 text-white'
+                                        : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-600'
+                                }`}
+                            >
+                                {getCategoryName(cat)}
+                            </button>
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            {/* Skills list */}
+            <div className="max-h-64 overflow-y-auto">
+                {loading ? (
+                    <div className="p-4 text-center text-neutral-500 dark:text-neutral-400 text-sm">
+                        Loading skills...
+                    </div>
+                ) : error ? (
+                    <div className="p-4 text-center text-red-500 text-sm">
+                        {error}
+                        <button
+                            onClick={loadSkills}
+                            className="ml-2 text-blue-500 hover:underline"
+                        >
+                            Retry
+                        </button>
+                    </div>
+                ) : filteredSkills.length === 0 ? (
+                    <div className="p-4 text-center text-neutral-500 dark:text-neutral-400 text-sm">
+                        {skills.length === 0 ? (
+                            <div>
+                                <p>No skills yet.</p>
+                                {onCreateNew && (
+                                    <button
+                                        onClick={onCreateNew}
+                                        className="mt-2 text-purple-500 hover:text-purple-600 flex items-center justify-center gap-1 mx-auto"
+                                    >
+                                        <IconPlus size={16} />
+                                        Create your first skill
+                                    </button>
+                                )}
+                            </div>
+                        ) : (
+                            "No matching skills found."
+                        )}
+                    </div>
+                ) : (
+                    filteredSkills.map(skill => {
+                        const isSelected = selectedSkillIds.includes(skill.id);
+                        return (
+                            <div
+                                key={skill.id}
+                                onClick={() => toggleSkill(skill.id)}
+                                className={`flex items-start gap-3 p-3 cursor-pointer border-b border-neutral-100 dark:border-neutral-700 last:border-0 hover:bg-neutral-50 dark:hover:bg-[#40414f] transition-colors ${
+                                    isSelected ? 'bg-purple-50 dark:bg-purple-900/20' : ''
+                                }`}
+                            >
+                                <div className={`w-5 h-5 rounded border flex items-center justify-center flex-shrink-0 mt-0.5 transition-colors ${
+                                    isSelected
+                                        ? 'bg-purple-500 border-purple-500 text-white'
+                                        : 'border-neutral-300 dark:border-neutral-600'
+                                }`}>
+                                    {isSelected && <IconCheck size={14} />}
+                                </div>
+                                <div className="flex-1 min-w-0">
+                                    <div className="flex items-center gap-2">
+                                        <span className="font-medium text-neutral-800 dark:text-neutral-200 truncate">
+                                            {skill.name}
+                                        </span>
+                                        {skill.isShared && (
+                                            <span className="px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 rounded text-xs">
+                                                shared
+                                            </span>
+                                        )}
+                                        <span className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-700 text-neutral-500 dark:text-neutral-400 rounded text-xs">
+                                            P{skill.priority}
+                                        </span>
+                                    </div>
+                                    {skill.description && (
+                                        <p className="text-sm text-neutral-500 dark:text-neutral-400 truncate mt-0.5">
+                                            {skill.description}
+                                        </p>
+                                    )}
+                                    {skill.tags && skill.tags.length > 0 && (
+                                        <div className="flex flex-wrap gap-1 mt-1">
+                                            {skill.tags.slice(0, 3).map(tag => (
+                                                <span
+                                                    key={tag}
+                                                    className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-400 rounded text-xs"
+                                                >
+                                                    {tag}
+                                                </span>
+                                            ))}
+                                            {skill.tags.length > 3 && (
+                                                <span className="text-xs text-neutral-400">
+                                                    +{skill.tags.length - 3}
+                                                </span>
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                        );
+                    })
+                )}
+            </div>
+
+            {/* Footer with selection info */}
+            {selectedSkillIds.length > 0 && (
+                <div className="p-2 border-t border-neutral-200 dark:border-neutral-600 bg-neutral-50 dark:bg-[#2a2b32]">
+                    <div className="flex items-center justify-between text-xs text-neutral-500 dark:text-neutral-400">
+                        <span>{selectedSkillIds.length} of {maxSelections} max selected</span>
+                        <button
+                            onClick={() => onSelectionChange([])}
+                            className="text-red-500 hover:text-red-600"
+                        >
+                            Clear all
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default SkillSelector;

--- a/components/Skills/SkillsLibrary.tsx
+++ b/components/Skills/SkillsLibrary.tsx
@@ -1,0 +1,472 @@
+import React, { useState, useEffect, FC, useCallback } from 'react';
+import {
+    IconBrain,
+    IconPlus,
+    IconSearch,
+    IconRefresh,
+    IconEdit,
+    IconTrash,
+    IconShare,
+    IconToggleLeft,
+    IconToggleRight,
+    IconGlobe,
+    IconLock,
+    IconDotsVertical,
+    IconCopy
+} from '@tabler/icons-react';
+import { Skill, CreateSkillData, UpdateSkillData, SKILL_CATEGORIES } from '@/types/skill';
+import {
+    getUserSkills,
+    createSkill,
+    updateSkill,
+    deleteSkill,
+    getPublicSkills
+} from '@/services/skillsService';
+import { SkillEditor } from './SkillEditor';
+
+interface SkillsLibraryProps {
+    onClose?: () => void;
+}
+
+type ViewMode = 'my-skills' | 'public';
+
+export const SkillsLibrary: FC<SkillsLibraryProps> = ({ onClose }) => {
+    const [skills, setSkills] = useState<Skill[]>([]);
+    const [publicSkills, setPublicSkills] = useState<Skill[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [filterCategory, setFilterCategory] = useState<string | null>(null);
+    const [viewMode, setViewMode] = useState<ViewMode>('my-skills');
+
+    // Editor state
+    const [showEditor, setShowEditor] = useState(false);
+    const [editingSkill, setEditingSkill] = useState<Skill | undefined>();
+    const [saving, setSaving] = useState(false);
+
+    // Dropdown menu state
+    const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+
+    const loadSkills = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+
+        try {
+            const [userResponse, publicResponse] = await Promise.all([
+                getUserSkills(true),
+                getPublicSkills(50)
+            ]);
+
+            if (userResponse.success && userResponse.data) {
+                setSkills(userResponse.data);
+            }
+
+            if (publicResponse.success && publicResponse.data) {
+                setPublicSkills(publicResponse.data);
+            }
+        } catch (err) {
+            console.error('Failed to load skills:', err);
+            setError('Failed to load skills');
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        loadSkills();
+    }, [loadSkills]);
+
+    // Close dropdown when clicking outside
+    useEffect(() => {
+        const handleClickOutside = () => setOpenMenuId(null);
+        document.addEventListener('click', handleClickOutside);
+        return () => document.removeEventListener('click', handleClickOutside);
+    }, []);
+
+    const displayedSkills = viewMode === 'my-skills' ? skills : publicSkills;
+
+    const allCategories = [...new Set(displayedSkills.map(s => s.category).filter(Boolean))];
+
+    const filteredSkills = displayedSkills.filter(skill => {
+        const matchesSearch = !searchQuery ||
+            skill.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+            skill.description?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+            skill.tags?.some(t => t.toLowerCase().includes(searchQuery.toLowerCase()));
+        const matchesCategory = !filterCategory || skill.category === filterCategory;
+        return matchesSearch && matchesCategory;
+    });
+
+    const getCategoryName = (categoryId: string) => {
+        return SKILL_CATEGORIES.find(c => c.id === categoryId)?.name || categoryId;
+    };
+
+    const handleCreateNew = () => {
+        setEditingSkill(undefined);
+        setShowEditor(true);
+    };
+
+    const handleEdit = (skill: Skill) => {
+        setEditingSkill(skill);
+        setShowEditor(true);
+        setOpenMenuId(null);
+    };
+
+    const handleSaveSkill = async (skillData: CreateSkillData | UpdateSkillData) => {
+        setSaving(true);
+        try {
+            if (editingSkill) {
+                const response = await updateSkill(editingSkill.id, skillData);
+                if (response.success) {
+                    await loadSkills();
+                    setShowEditor(false);
+                    setEditingSkill(undefined);
+                } else {
+                    alert(response.message || 'Failed to update skill');
+                }
+            } else {
+                const response = await createSkill(skillData as CreateSkillData);
+                if (response.success) {
+                    await loadSkills();
+                    setShowEditor(false);
+                } else {
+                    alert(response.message || 'Failed to create skill');
+                }
+            }
+        } catch (err) {
+            console.error('Failed to save skill:', err);
+            alert('Failed to save skill');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleDelete = async (skill: Skill) => {
+        if (!confirm(`Are you sure you want to delete "${skill.name}"? This cannot be undone.`)) {
+            return;
+        }
+
+        try {
+            const response = await deleteSkill(skill.id);
+            if (response.success) {
+                await loadSkills();
+            } else {
+                alert(response.message || 'Failed to delete skill');
+            }
+        } catch (err) {
+            console.error('Failed to delete skill:', err);
+            alert('Failed to delete skill');
+        }
+        setOpenMenuId(null);
+    };
+
+    const handleToggleEnabled = async (skill: Skill) => {
+        try {
+            const response = await updateSkill(skill.id, { isEnabled: !skill.isEnabled });
+            if (response.success) {
+                await loadSkills();
+            }
+        } catch (err) {
+            console.error('Failed to toggle skill:', err);
+        }
+        setOpenMenuId(null);
+    };
+
+    const handleDuplicatePublicSkill = async (skill: Skill) => {
+        setSaving(true);
+        try {
+            const newSkillData: CreateSkillData = {
+                name: `${skill.name} (Copy)`,
+                description: skill.description,
+                content: skill.content,
+                tags: skill.tags,
+                triggerPhrases: skill.triggerPhrases,
+                priority: skill.priority,
+                category: skill.category,
+                isPublic: false
+            };
+
+            const response = await createSkill(newSkillData);
+            if (response.success) {
+                await loadSkills();
+                setViewMode('my-skills');
+                alert('Skill copied to your library!');
+            } else {
+                alert(response.message || 'Failed to copy skill');
+            }
+        } catch (err) {
+            console.error('Failed to copy skill:', err);
+            alert('Failed to copy skill');
+        } finally {
+            setSaving(false);
+        }
+        setOpenMenuId(null);
+    };
+
+    if (showEditor) {
+        return (
+            <div className="h-full">
+                <SkillEditor
+                    skill={editingSkill}
+                    onSave={handleSaveSkill}
+                    onCancel={() => {
+                        setShowEditor(false);
+                        setEditingSkill(undefined);
+                    }}
+                    isLoading={saving}
+                />
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col h-full bg-white dark:bg-[#343541]">
+            {/* Header */}
+            <div className="p-4 border-b border-neutral-200 dark:border-neutral-600">
+                <div className="flex items-center justify-between mb-4">
+                    <div className="flex items-center gap-3">
+                        <IconBrain size={28} className="text-purple-500" />
+                        <h1 className="text-2xl font-bold text-neutral-800 dark:text-neutral-200">
+                            Skills Library
+                        </h1>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <button
+                            onClick={loadSkills}
+                            className="p-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded text-neutral-600 dark:text-neutral-400"
+                            title="Refresh"
+                            disabled={loading}
+                        >
+                            <IconRefresh size={20} className={loading ? 'animate-spin' : ''} />
+                        </button>
+                        <button
+                            onClick={handleCreateNew}
+                            className="flex items-center gap-2 px-4 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 transition-colors"
+                        >
+                            <IconPlus size={18} />
+                            New Skill
+                        </button>
+                    </div>
+                </div>
+
+                {/* View mode tabs */}
+                <div className="flex gap-2 mb-4">
+                    <button
+                        onClick={() => setViewMode('my-skills')}
+                        className={`px-4 py-2 rounded-lg transition-colors ${
+                            viewMode === 'my-skills'
+                                ? 'bg-purple-500 text-white'
+                                : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'
+                        }`}
+                    >
+                        My Skills ({skills.length})
+                    </button>
+                    <button
+                        onClick={() => setViewMode('public')}
+                        className={`px-4 py-2 rounded-lg transition-colors ${
+                            viewMode === 'public'
+                                ? 'bg-purple-500 text-white'
+                                : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'
+                        }`}
+                    >
+                        <IconGlobe size={16} className="inline mr-1" />
+                        Discover ({publicSkills.length})
+                    </button>
+                </div>
+
+                {/* Search and filters */}
+                <div className="flex gap-4">
+                    <div className="relative flex-1">
+                        <IconSearch size={18} className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400" />
+                        <input
+                            type="text"
+                            value={searchQuery}
+                            onChange={(e) => setSearchQuery(e.target.value)}
+                            placeholder="Search skills..."
+                            className="w-full pl-10 pr-4 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-[#40414f] text-neutral-900 dark:text-white focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                        />
+                    </div>
+                    <select
+                        value={filterCategory || ''}
+                        onChange={(e) => setFilterCategory(e.target.value || null)}
+                        className="px-4 py-2 border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-[#40414f] text-neutral-900 dark:text-white focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                    >
+                        <option value="">All Categories</option>
+                        {SKILL_CATEGORIES.map(cat => (
+                            <option key={cat.id} value={cat.id}>{cat.name}</option>
+                        ))}
+                    </select>
+                </div>
+            </div>
+
+            {/* Skills grid */}
+            <div className="flex-1 overflow-y-auto p-4">
+                {loading ? (
+                    <div className="flex items-center justify-center h-64">
+                        <div className="text-center">
+                            <IconRefresh size={32} className="animate-spin mx-auto mb-2 text-purple-500" />
+                            <p className="text-neutral-500 dark:text-neutral-400">Loading skills...</p>
+                        </div>
+                    </div>
+                ) : error ? (
+                    <div className="flex items-center justify-center h-64">
+                        <div className="text-center">
+                            <p className="text-red-500 mb-2">{error}</p>
+                            <button
+                                onClick={loadSkills}
+                                className="text-purple-500 hover:text-purple-600"
+                            >
+                                Try again
+                            </button>
+                        </div>
+                    </div>
+                ) : filteredSkills.length === 0 ? (
+                    <div className="flex items-center justify-center h-64">
+                        <div className="text-center">
+                            <IconBrain size={48} className="mx-auto mb-4 text-neutral-300 dark:text-neutral-600" />
+                            <p className="text-neutral-500 dark:text-neutral-400 mb-4">
+                                {skills.length === 0 && viewMode === 'my-skills'
+                                    ? "You haven't created any skills yet."
+                                    : "No matching skills found."}
+                            </p>
+                            {skills.length === 0 && viewMode === 'my-skills' && (
+                                <button
+                                    onClick={handleCreateNew}
+                                    className="flex items-center gap-2 px-4 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 mx-auto"
+                                >
+                                    <IconPlus size={18} />
+                                    Create your first skill
+                                </button>
+                            )}
+                        </div>
+                    </div>
+                ) : (
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                        {filteredSkills.map(skill => (
+                            <div
+                                key={skill.id}
+                                className={`bg-neutral-50 dark:bg-[#40414f] rounded-lg border border-neutral-200 dark:border-neutral-600 p-4 hover:shadow-md transition-shadow ${
+                                    !skill.isEnabled && viewMode === 'my-skills' ? 'opacity-60' : ''
+                                }`}
+                            >
+                                <div className="flex items-start justify-between mb-2">
+                                    <div className="flex items-center gap-2">
+                                        <h3 className="font-semibold text-neutral-800 dark:text-neutral-200 truncate">
+                                            {skill.name}
+                                        </h3>
+                                        {skill.isPublic && (
+                                            <IconGlobe size={14} className="text-green-500" title="Public" />
+                                        )}
+                                        {skill.isShared && (
+                                            <IconShare size={14} className="text-blue-500" title="Shared with you" />
+                                        )}
+                                    </div>
+                                    <div className="relative">
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                setOpenMenuId(openMenuId === skill.id ? null : skill.id);
+                                            }}
+                                            className="p-1 hover:bg-neutral-200 dark:hover:bg-neutral-600 rounded"
+                                        >
+                                            <IconDotsVertical size={16} className="text-neutral-500" />
+                                        </button>
+
+                                        {/* Dropdown menu */}
+                                        {openMenuId === skill.id && (
+                                            <div className="absolute right-0 top-full mt-1 w-48 bg-white dark:bg-[#343541] rounded-lg shadow-lg border border-neutral-200 dark:border-neutral-600 z-10">
+                                                {viewMode === 'my-skills' ? (
+                                                    <>
+                                                        <button
+                                                            onClick={() => handleEdit(skill)}
+                                                            className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300"
+                                                        >
+                                                            <IconEdit size={16} />
+                                                            Edit
+                                                        </button>
+                                                        <button
+                                                            onClick={() => handleToggleEnabled(skill)}
+                                                            className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300"
+                                                        >
+                                                            {skill.isEnabled ? (
+                                                                <>
+                                                                    <IconToggleLeft size={16} />
+                                                                    Disable
+                                                                </>
+                                                            ) : (
+                                                                <>
+                                                                    <IconToggleRight size={16} />
+                                                                    Enable
+                                                                </>
+                                                            )}
+                                                        </button>
+                                                        <button
+                                                            onClick={() => handleDelete(skill)}
+                                                            className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm hover:bg-red-50 dark:hover:bg-red-900/20 text-red-600"
+                                                        >
+                                                            <IconTrash size={16} />
+                                                            Delete
+                                                        </button>
+                                                    </>
+                                                ) : (
+                                                    <button
+                                                        onClick={() => handleDuplicatePublicSkill(skill)}
+                                                        className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-300"
+                                                    >
+                                                        <IconCopy size={16} />
+                                                        Copy to My Skills
+                                                    </button>
+                                                )}
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+
+                                <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-3 line-clamp-2">
+                                    {skill.description || 'No description'}
+                                </p>
+
+                                <div className="flex items-center justify-between text-xs">
+                                    <div className="flex items-center gap-2">
+                                        <span className="px-2 py-0.5 bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-300 rounded">
+                                            P{skill.priority}
+                                        </span>
+                                        {skill.category && (
+                                            <span className="px-2 py-0.5 bg-neutral-200 dark:bg-neutral-600 text-neutral-600 dark:text-neutral-400 rounded">
+                                                {getCategoryName(skill.category)}
+                                            </span>
+                                        )}
+                                    </div>
+                                    {skill.metadata?.usageCount > 0 && (
+                                        <span className="text-neutral-400">
+                                            Used {skill.metadata.usageCount}x
+                                        </span>
+                                    )}
+                                </div>
+
+                                {skill.tags && skill.tags.length > 0 && (
+                                    <div className="flex flex-wrap gap-1 mt-2">
+                                        {skill.tags.slice(0, 4).map(tag => (
+                                            <span
+                                                key={tag}
+                                                className="px-1.5 py-0.5 bg-neutral-200 dark:bg-neutral-600 text-neutral-600 dark:text-neutral-400 rounded text-xs"
+                                            >
+                                                {tag}
+                                            </span>
+                                        ))}
+                                        {skill.tags.length > 4 && (
+                                            <span className="text-xs text-neutral-400">
+                                                +{skill.tags.length - 4}
+                                            </span>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default SkillsLibrary;

--- a/components/Skills/SkillsLibrary.tsx
+++ b/components/Skills/SkillsLibrary.tsx
@@ -205,7 +205,7 @@ export const SkillsLibrary: FC<SkillsLibraryProps> = ({ chatEndpoint, onClose })
 
     if (showEditor) {
         return (
-            <div className="h-full">
+            <div className="h-full max-h-full overflow-hidden">
                 <SkillEditor
                     skill={editingSkill}
                     onSave={handleSaveSkill}

--- a/components/Skills/SkillsLibrary.tsx
+++ b/components/Skills/SkillsLibrary.tsx
@@ -25,12 +25,13 @@ import {
 import { SkillEditor } from './SkillEditor';
 
 interface SkillsLibraryProps {
+    chatEndpoint: string;
     onClose?: () => void;
 }
 
 type ViewMode = 'my-skills' | 'public';
 
-export const SkillsLibrary: FC<SkillsLibraryProps> = ({ onClose }) => {
+export const SkillsLibrary: FC<SkillsLibraryProps> = ({ chatEndpoint, onClose }) => {
     const [skills, setSkills] = useState<Skill[]>([]);
     const [publicSkills, setPublicSkills] = useState<Skill[]>([]);
     const [loading, setLoading] = useState(true);
@@ -53,8 +54,8 @@ export const SkillsLibrary: FC<SkillsLibraryProps> = ({ onClose }) => {
 
         try {
             const [userResponse, publicResponse] = await Promise.all([
-                getUserSkills(true),
-                getPublicSkills(50)
+                getUserSkills(chatEndpoint, true),
+                getPublicSkills(chatEndpoint, 50)
             ]);
 
             if (userResponse.success && userResponse.data) {
@@ -70,7 +71,7 @@ export const SkillsLibrary: FC<SkillsLibraryProps> = ({ onClose }) => {
         } finally {
             setLoading(false);
         }
-    }, []);
+    }, [chatEndpoint]);
 
     useEffect(() => {
         loadSkills();
@@ -115,7 +116,7 @@ export const SkillsLibrary: FC<SkillsLibraryProps> = ({ onClose }) => {
         setSaving(true);
         try {
             if (editingSkill) {
-                const response = await updateSkill(editingSkill.id, skillData);
+                const response = await updateSkill(chatEndpoint, editingSkill.id, skillData);
                 if (response.success) {
                     await loadSkills();
                     setShowEditor(false);
@@ -124,7 +125,7 @@ export const SkillsLibrary: FC<SkillsLibraryProps> = ({ onClose }) => {
                     alert(response.message || 'Failed to update skill');
                 }
             } else {
-                const response = await createSkill(skillData as CreateSkillData);
+                const response = await createSkill(chatEndpoint, skillData as CreateSkillData);
                 if (response.success) {
                     await loadSkills();
                     setShowEditor(false);
@@ -146,7 +147,7 @@ export const SkillsLibrary: FC<SkillsLibraryProps> = ({ onClose }) => {
         }
 
         try {
-            const response = await deleteSkill(skill.id);
+            const response = await deleteSkill(chatEndpoint, skill.id);
             if (response.success) {
                 await loadSkills();
             } else {
@@ -161,7 +162,7 @@ export const SkillsLibrary: FC<SkillsLibraryProps> = ({ onClose }) => {
 
     const handleToggleEnabled = async (skill: Skill) => {
         try {
-            const response = await updateSkill(skill.id, { isEnabled: !skill.isEnabled });
+            const response = await updateSkill(chatEndpoint, skill.id, { isEnabled: !skill.isEnabled });
             if (response.success) {
                 await loadSkills();
             }
@@ -185,7 +186,7 @@ export const SkillsLibrary: FC<SkillsLibraryProps> = ({ onClose }) => {
                 isPublic: false
             };
 
-            const response = await createSkill(newSkillData);
+            const response = await createSkill(chatEndpoint, newSkillData);
             if (response.success) {
                 await loadSkills();
                 setViewMode('my-skills');

--- a/components/Skills/SkillsSection.tsx
+++ b/components/Skills/SkillsSection.tsx
@@ -305,12 +305,14 @@ export const SkillsSection: FC<SkillsSectionProps> = ({
             {/* Editor modal */}
             {showEditor && (
                 <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-                    <div className="w-full max-w-4xl max-h-[90vh] bg-white dark:bg-[#343541] rounded-lg shadow-2xl overflow-hidden">
-                        <SkillEditor
-                            onSave={handleCreateNew}
-                            onCancel={() => setShowEditor(false)}
-                            isLoading={saving}
-                        />
+                    <div className="w-full max-w-4xl max-h-[90vh] bg-white dark:bg-[#343541] rounded-lg shadow-2xl flex flex-col overflow-hidden">
+                        <div className="flex-1 overflow-y-auto">
+                            <SkillEditor
+                                onSave={handleCreateNew}
+                                onCancel={() => setShowEditor(false)}
+                                isLoading={saving}
+                            />
+                        </div>
                     </div>
                 </div>
             )}

--- a/components/Skills/SkillsSection.tsx
+++ b/components/Skills/SkillsSection.tsx
@@ -15,6 +15,7 @@ import { createSkill } from '@/services/skillsService';
 import { CreateSkillData } from '@/types/skill';
 
 interface SkillsSectionProps {
+    chatEndpoint: string;
     selectedSkills: SkillReference[];
     onSkillsChange: (skills: SkillReference[]) => void;
     skillSelectionMode: SkillSelectionMode;
@@ -22,6 +23,7 @@ interface SkillsSectionProps {
 }
 
 export const SkillsSection: FC<SkillsSectionProps> = ({
+    chatEndpoint,
     selectedSkills,
     onSkillsChange,
     skillSelectionMode,
@@ -41,7 +43,7 @@ export const SkillsSection: FC<SkillsSectionProps> = ({
     const loadSkills = async () => {
         setLoading(true);
         try {
-            const response = await getUserSkills(true);
+            const response = await getUserSkills(chatEndpoint, true);
             if (response.success && response.data) {
                 setSkills(response.data);
             }
@@ -77,7 +79,7 @@ export const SkillsSection: FC<SkillsSectionProps> = ({
     const handleCreateNew = async (skillData: CreateSkillData) => {
         setSaving(true);
         try {
-            const response = await createSkill(skillData);
+            const response = await createSkill(chatEndpoint, skillData);
             if (response.success && response.data) {
                 await loadSkills();
                 // Automatically select the newly created skill

--- a/components/Skills/SkillsSection.tsx
+++ b/components/Skills/SkillsSection.tsx
@@ -1,0 +1,321 @@
+import React, { useState, useEffect, FC } from 'react';
+import {
+    IconBrain,
+    IconPlus,
+    IconX,
+    IconCheck,
+    IconSearch,
+    IconChevronDown,
+    IconChevronUp
+} from '@tabler/icons-react';
+import { Skill, SkillReference, SkillSelectionMode, SKILL_CATEGORIES } from '@/types/skill';
+import { getUserSkills } from '@/services/skillsService';
+import { SkillEditor } from './SkillEditor';
+import { createSkill } from '@/services/skillsService';
+import { CreateSkillData } from '@/types/skill';
+
+interface SkillsSectionProps {
+    selectedSkills: SkillReference[];
+    onSkillsChange: (skills: SkillReference[]) => void;
+    skillSelectionMode: SkillSelectionMode;
+    onModeChange: (mode: SkillSelectionMode) => void;
+}
+
+export const SkillsSection: FC<SkillsSectionProps> = ({
+    selectedSkills,
+    onSkillsChange,
+    skillSelectionMode,
+    onModeChange
+}) => {
+    const [skills, setSkills] = useState<Skill[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [expanded, setExpanded] = useState(true);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [showEditor, setShowEditor] = useState(false);
+    const [saving, setSaving] = useState(false);
+
+    useEffect(() => {
+        loadSkills();
+    }, []);
+
+    const loadSkills = async () => {
+        setLoading(true);
+        try {
+            const response = await getUserSkills(true);
+            if (response.success && response.data) {
+                setSkills(response.data);
+            }
+        } catch (err) {
+            console.error('Failed to load skills:', err);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const filteredSkills = skills.filter(skill => {
+        const matchesSearch = !searchQuery ||
+            skill.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+            skill.description?.toLowerCase().includes(searchQuery.toLowerCase());
+        return matchesSearch && skill.isEnabled;
+    });
+
+    const toggleSkill = (skillId: string) => {
+        const existing = selectedSkills.find(s => s.skillId === skillId);
+        if (existing) {
+            onSkillsChange(selectedSkills.filter(s => s.skillId !== skillId));
+        } else {
+            onSkillsChange([...selectedSkills, { skillId, isRequired: true }]);
+        }
+    };
+
+    const toggleRequired = (skillId: string) => {
+        onSkillsChange(selectedSkills.map(s =>
+            s.skillId === skillId ? { ...s, isRequired: !s.isRequired } : s
+        ));
+    };
+
+    const handleCreateNew = async (skillData: CreateSkillData) => {
+        setSaving(true);
+        try {
+            const response = await createSkill(skillData);
+            if (response.success && response.data) {
+                await loadSkills();
+                // Automatically select the newly created skill
+                onSkillsChange([...selectedSkills, { skillId: response.data.id, isRequired: true }]);
+                setShowEditor(false);
+            } else {
+                alert(response.message || 'Failed to create skill');
+            }
+        } catch (err) {
+            console.error('Failed to create skill:', err);
+            alert('Failed to create skill');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const getSkillById = (skillId: string) => skills.find(s => s.id === skillId);
+
+    return (
+        <div className="border border-neutral-200 dark:border-neutral-600 rounded-lg overflow-hidden">
+            {/* Header */}
+            <button
+                onClick={() => setExpanded(!expanded)}
+                className="w-full flex items-center justify-between p-4 bg-neutral-50 dark:bg-[#2a2b32] hover:bg-neutral-100 dark:hover:bg-[#343541] transition-colors"
+            >
+                <div className="flex items-center gap-3">
+                    <IconBrain size={24} className="text-purple-500" />
+                    <div className="text-left">
+                        <h3 className="font-semibold text-neutral-800 dark:text-neutral-200">
+                            Skills
+                        </h3>
+                        <p className="text-sm text-neutral-500 dark:text-neutral-400">
+                            Attach skills to give your assistant specialized capabilities
+                        </p>
+                    </div>
+                </div>
+                <div className="flex items-center gap-2">
+                    {selectedSkills.length > 0 && (
+                        <span className="px-2 py-1 bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-300 rounded text-sm">
+                            {selectedSkills.length} selected
+                        </span>
+                    )}
+                    {expanded ? <IconChevronUp size={20} /> : <IconChevronDown size={20} />}
+                </div>
+            </button>
+
+            {/* Content */}
+            {expanded && (
+                <div className="p-4 space-y-4">
+                    {/* Selection mode */}
+                    <div>
+                        <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
+                            Skill Selection Mode
+                        </label>
+                        <div className="flex gap-2">
+                            {(['auto', 'manual', 'hybrid'] as SkillSelectionMode[]).map(mode => (
+                                <button
+                                    key={mode}
+                                    onClick={() => onModeChange(mode)}
+                                    className={`px-4 py-2 rounded-lg text-sm transition-colors ${
+                                        skillSelectionMode === mode
+                                            ? 'bg-purple-500 text-white'
+                                            : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'
+                                    }`}
+                                >
+                                    {mode === 'auto' && 'Auto-select'}
+                                    {mode === 'manual' && 'Manual only'}
+                                    {mode === 'hybrid' && 'Required + Auto'}
+                                </button>
+                            ))}
+                        </div>
+                        <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+                            {skillSelectionMode === 'auto' && 'Skills will be automatically selected based on conversation context'}
+                            {skillSelectionMode === 'manual' && 'Only manually selected skills will be used'}
+                            {skillSelectionMode === 'hybrid' && 'Required skills are always used, plus auto-selection from others'}
+                        </p>
+                    </div>
+
+                    {/* Search and add */}
+                    <div className="flex gap-2">
+                        <div className="relative flex-1">
+                            <IconSearch size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-400" />
+                            <input
+                                type="text"
+                                value={searchQuery}
+                                onChange={(e) => setSearchQuery(e.target.value)}
+                                placeholder="Search skills..."
+                                className="w-full pl-9 pr-3 py-2 text-sm border border-neutral-300 dark:border-neutral-600 rounded-lg bg-white dark:bg-[#40414f] text-neutral-900 dark:text-white focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                            />
+                        </div>
+                        <button
+                            onClick={() => setShowEditor(true)}
+                            className="flex items-center gap-1 px-3 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 text-sm"
+                        >
+                            <IconPlus size={16} />
+                            New
+                        </button>
+                    </div>
+
+                    {/* Selected skills */}
+                    {selectedSkills.length > 0 && (
+                        <div>
+                            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
+                                Selected Skills
+                            </label>
+                            <div className="space-y-2">
+                                {selectedSkills.map(skillRef => {
+                                    const skill = getSkillById(skillRef.skillId);
+                                    if (!skill) return null;
+
+                                    return (
+                                        <div
+                                            key={skillRef.skillId}
+                                            className="flex items-center justify-between p-3 bg-purple-50 dark:bg-purple-900/20 border border-purple-200 dark:border-purple-800 rounded-lg"
+                                        >
+                                            <div className="flex items-center gap-2">
+                                                <IconBrain size={18} className="text-purple-500" />
+                                                <span className="font-medium text-neutral-800 dark:text-neutral-200">
+                                                    {skill.name}
+                                                </span>
+                                                {skill.isShared && (
+                                                    <span className="px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 rounded text-xs">
+                                                        shared
+                                                    </span>
+                                                )}
+                                            </div>
+                                            <div className="flex items-center gap-2">
+                                                <label className="flex items-center gap-1 text-sm text-neutral-600 dark:text-neutral-400">
+                                                    <input
+                                                        type="checkbox"
+                                                        checked={skillRef.isRequired}
+                                                        onChange={() => toggleRequired(skillRef.skillId)}
+                                                        className="rounded border-neutral-300 dark:border-neutral-600 text-purple-500 focus:ring-purple-500"
+                                                    />
+                                                    Always include
+                                                </label>
+                                                <button
+                                                    onClick={() => toggleSkill(skillRef.skillId)}
+                                                    className="p-1 text-neutral-400 hover:text-red-500"
+                                                >
+                                                    <IconX size={16} />
+                                                </button>
+                                            </div>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Available skills */}
+                    <div>
+                        <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
+                            Available Skills
+                        </label>
+                        {loading ? (
+                            <div className="p-4 text-center text-neutral-500 dark:text-neutral-400 text-sm">
+                                Loading skills...
+                            </div>
+                        ) : filteredSkills.length === 0 ? (
+                            <div className="p-4 text-center text-neutral-500 dark:text-neutral-400 text-sm">
+                                {skills.length === 0 ? (
+                                    <div>
+                                        <p>No skills available.</p>
+                                        <button
+                                            onClick={() => setShowEditor(true)}
+                                            className="mt-2 text-purple-500 hover:text-purple-600"
+                                        >
+                                            Create your first skill
+                                        </button>
+                                    </div>
+                                ) : (
+                                    "No matching skills found."
+                                )}
+                            </div>
+                        ) : (
+                            <div className="max-h-60 overflow-y-auto border border-neutral-200 dark:border-neutral-600 rounded-lg divide-y divide-neutral-100 dark:divide-neutral-700">
+                                {filteredSkills.map(skill => {
+                                    const isSelected = selectedSkills.some(s => s.skillId === skill.id);
+
+                                    return (
+                                        <div
+                                            key={skill.id}
+                                            onClick={() => toggleSkill(skill.id)}
+                                            className={`flex items-center gap-3 p-3 cursor-pointer hover:bg-neutral-50 dark:hover:bg-[#40414f] transition-colors ${
+                                                isSelected ? 'bg-purple-50 dark:bg-purple-900/10' : ''
+                                            }`}
+                                        >
+                                            <div className={`w-5 h-5 rounded border flex items-center justify-center flex-shrink-0 ${
+                                                isSelected
+                                                    ? 'bg-purple-500 border-purple-500 text-white'
+                                                    : 'border-neutral-300 dark:border-neutral-600'
+                                            }`}>
+                                                {isSelected && <IconCheck size={14} />}
+                                            </div>
+                                            <div className="flex-1 min-w-0">
+                                                <div className="flex items-center gap-2">
+                                                    <span className="font-medium text-neutral-800 dark:text-neutral-200 truncate">
+                                                        {skill.name}
+                                                    </span>
+                                                    {skill.isShared && (
+                                                        <span className="px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 rounded text-xs">
+                                                            shared
+                                                        </span>
+                                                    )}
+                                                    <span className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-700 text-neutral-500 dark:text-neutral-400 rounded text-xs">
+                                                        P{skill.priority}
+                                                    </span>
+                                                </div>
+                                                {skill.description && (
+                                                    <p className="text-sm text-neutral-500 dark:text-neutral-400 truncate">
+                                                        {skill.description}
+                                                    </p>
+                                                )}
+                                            </div>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
+
+            {/* Editor modal */}
+            {showEditor && (
+                <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
+                    <div className="w-full max-w-4xl max-h-[90vh] bg-white dark:bg-[#343541] rounded-lg shadow-2xl overflow-hidden">
+                        <SkillEditor
+                            onSave={handleCreateNew}
+                            onCancel={() => setShowEditor(false)}
+                            isLoading={saving}
+                        />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default SkillsSection;

--- a/components/Skills/SkillsToggle.tsx
+++ b/components/Skills/SkillsToggle.tsx
@@ -1,0 +1,176 @@
+import React, { useState, useRef, useEffect, FC, useCallback } from 'react';
+import { IconBrain, IconX } from '@tabler/icons-react';
+import { Skill } from '@/types/skill';
+import { SkillSelector } from './SkillSelector';
+import { SkillEditor } from './SkillEditor';
+import { createSkill, getUserSkills } from '@/services/skillsService';
+import { CreateSkillData } from '@/types/skill';
+
+interface SkillsToggleProps {
+    selectedSkillIds: string[];
+    onSelectionChange: (skillIds: string[]) => void;
+    disabled?: boolean;
+}
+
+export const SkillsToggle: FC<SkillsToggleProps> = ({
+    selectedSkillIds,
+    onSelectionChange,
+    disabled = false
+}) => {
+    const [showSelector, setShowSelector] = useState(false);
+    const [showEditor, setShowEditor] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    // Close selector when clicking outside
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+                setShowSelector(false);
+            }
+        };
+
+        if (showSelector) {
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [showSelector]);
+
+    const handleCreateNew = () => {
+        setShowSelector(false);
+        setShowEditor(true);
+    };
+
+    const handleSaveNewSkill = async (skillData: CreateSkillData) => {
+        setSaving(true);
+        try {
+            const response = await createSkill(skillData);
+            if (response.success && response.data) {
+                // Automatically select the newly created skill
+                onSelectionChange([...selectedSkillIds, response.data.id]);
+                setShowEditor(false);
+            } else {
+                alert(response.message || 'Failed to create skill');
+            }
+        } catch (err) {
+            console.error('Failed to create skill:', err);
+            alert('Failed to create skill');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const isActive = selectedSkillIds.length > 0;
+
+    return (
+        <div ref={containerRef} className="relative inline-block">
+            {/* Toggle button */}
+            <button
+                onClick={() => !disabled && setShowSelector(!showSelector)}
+                disabled={disabled}
+                className={`relative p-2 rounded-lg transition-all ${
+                    isActive
+                        ? 'bg-purple-100 dark:bg-purple-900/40 text-purple-600 dark:text-purple-400 hover:bg-purple-200 dark:hover:bg-purple-900/60'
+                        : 'text-neutral-500 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-neutral-700'
+                } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                title={`Skills${isActive ? ` (${selectedSkillIds.length} active)` : ''}`}
+            >
+                <IconBrain size={20} />
+                {isActive && (
+                    <span className="absolute -top-1 -right-1 w-4 h-4 bg-purple-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center">
+                        {selectedSkillIds.length}
+                    </span>
+                )}
+            </button>
+
+            {/* Selector dropdown */}
+            {showSelector && !showEditor && (
+                <div className="absolute bottom-full mb-2 right-0 w-80 z-50 shadow-xl">
+                    <SkillSelector
+                        selectedSkillIds={selectedSkillIds}
+                        onSelectionChange={onSelectionChange}
+                        onCreateNew={handleCreateNew}
+                        compact={false}
+                        maxSelections={3}
+                    />
+                </div>
+            )}
+
+            {/* Editor modal */}
+            {showEditor && (
+                <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
+                    <div className="w-full max-w-4xl max-h-[90vh] bg-white dark:bg-[#343541] rounded-lg shadow-2xl overflow-hidden">
+                        <SkillEditor
+                            onSave={handleSaveNewSkill}
+                            onCancel={() => setShowEditor(false)}
+                            isLoading={saving}
+                        />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+/**
+ * Active Skills Display - Shows currently selected skills in the chat area
+ */
+interface ActiveSkillsDisplayProps {
+    skillIds: string[];
+    onRemove: (skillId: string) => void;
+}
+
+export const ActiveSkillsDisplay: FC<ActiveSkillsDisplayProps> = ({
+    skillIds,
+    onRemove
+}) => {
+    const [skills, setSkills] = useState<Skill[]>([]);
+
+    useEffect(() => {
+        const loadSkillNames = async () => {
+            if (skillIds.length === 0) {
+                setSkills([]);
+                return;
+            }
+
+            try {
+                const response = await getUserSkills(true);
+                if (response.success && response.data) {
+                    const selectedSkills = response.data.filter(s => skillIds.includes(s.id));
+                    setSkills(selectedSkills);
+                }
+            } catch (err) {
+                console.error('Failed to load skill names:', err);
+            }
+        };
+
+        loadSkillNames();
+    }, [skillIds]);
+
+    if (skillIds.length === 0) return null;
+
+    return (
+        <div className="flex items-center gap-1 flex-wrap">
+            <IconBrain size={14} className="text-purple-500" />
+            {skills.map(skill => (
+                <span
+                    key={skill.id}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300 rounded text-xs"
+                >
+                    {skill.name}
+                    <button
+                        onClick={() => onRemove(skill.id)}
+                        className="hover:text-purple-900 dark:hover:text-purple-100"
+                    >
+                        <IconX size={12} />
+                    </button>
+                </span>
+            ))}
+        </div>
+    );
+};
+
+export default SkillsToggle;

--- a/components/Skills/SkillsToggle.tsx
+++ b/components/Skills/SkillsToggle.tsx
@@ -7,12 +7,14 @@ import { createSkill, getUserSkills } from '@/services/skillsService';
 import { CreateSkillData } from '@/types/skill';
 
 interface SkillsToggleProps {
+    chatEndpoint: string;
     selectedSkillIds: string[];
     onSelectionChange: (skillIds: string[]) => void;
     disabled?: boolean;
 }
 
 export const SkillsToggle: FC<SkillsToggleProps> = ({
+    chatEndpoint,
     selectedSkillIds,
     onSelectionChange,
     disabled = false
@@ -47,7 +49,7 @@ export const SkillsToggle: FC<SkillsToggleProps> = ({
     const handleSaveNewSkill = async (skillData: CreateSkillData) => {
         setSaving(true);
         try {
-            const response = await createSkill(skillData);
+            const response = await createSkill(chatEndpoint, skillData);
             if (response.success && response.data) {
                 // Automatically select the newly created skill
                 onSelectionChange([...selectedSkillIds, response.data.id]);
@@ -90,6 +92,7 @@ export const SkillsToggle: FC<SkillsToggleProps> = ({
             {showSelector && !showEditor && (
                 <div className="absolute bottom-full mb-2 right-0 w-80 z-50 shadow-xl">
                     <SkillSelector
+                        chatEndpoint={chatEndpoint}
                         selectedSkillIds={selectedSkillIds}
                         onSelectionChange={onSelectionChange}
                         onCreateNew={handleCreateNew}
@@ -121,11 +124,13 @@ export const SkillsToggle: FC<SkillsToggleProps> = ({
  * Active Skills Display - Shows currently selected skills in the chat area
  */
 interface ActiveSkillsDisplayProps {
+    chatEndpoint: string;
     skillIds: string[];
     onRemove: (skillId: string) => void;
 }
 
 export const ActiveSkillsDisplay: FC<ActiveSkillsDisplayProps> = ({
+    chatEndpoint,
     skillIds,
     onRemove
 }) => {
@@ -133,13 +138,13 @@ export const ActiveSkillsDisplay: FC<ActiveSkillsDisplayProps> = ({
 
     useEffect(() => {
         const loadSkillNames = async () => {
-            if (skillIds.length === 0) {
+            if (skillIds.length === 0 || !chatEndpoint) {
                 setSkills([]);
                 return;
             }
 
             try {
-                const response = await getUserSkills(true);
+                const response = await getUserSkills(chatEndpoint, true);
                 if (response.success && response.data) {
                     const selectedSkills = response.data.filter(s => skillIds.includes(s.id));
                     setSkills(selectedSkills);
@@ -150,7 +155,7 @@ export const ActiveSkillsDisplay: FC<ActiveSkillsDisplayProps> = ({
         };
 
         loadSkillNames();
-    }, [skillIds]);
+    }, [skillIds, chatEndpoint]);
 
     if (skillIds.length === 0) return null;
 

--- a/components/Skills/SkillsToggle.tsx
+++ b/components/Skills/SkillsToggle.tsx
@@ -102,12 +102,14 @@ export const SkillsToggle: FC<SkillsToggleProps> = ({
             {/* Editor modal */}
             {showEditor && (
                 <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-                    <div className="w-full max-w-4xl max-h-[90vh] bg-white dark:bg-[#343541] rounded-lg shadow-2xl overflow-hidden">
-                        <SkillEditor
-                            onSave={handleSaveNewSkill}
-                            onCancel={() => setShowEditor(false)}
-                            isLoading={saving}
-                        />
+                    <div className="w-full max-w-4xl max-h-[90vh] bg-white dark:bg-[#343541] rounded-lg shadow-2xl flex flex-col overflow-hidden">
+                        <div className="flex-1 overflow-y-auto">
+                            <SkillEditor
+                                onSave={handleSaveNewSkill}
+                                onCancel={() => setShowEditor(false)}
+                                isLoading={saving}
+                            />
+                        </div>
                     </div>
                 </div>
             )}

--- a/components/Skills/index.ts
+++ b/components/Skills/index.ts
@@ -1,0 +1,5 @@
+export { SkillEditor } from './SkillEditor';
+export { SkillSelector } from './SkillSelector';
+export { SkillsLibrary } from './SkillsLibrary';
+export { SkillsToggle, ActiveSkillsDisplay } from './SkillsToggle';
+export { SkillsSection } from './SkillsSection';

--- a/hooks/useChatSendService.ts
+++ b/hooks/useChatSendService.ts
@@ -360,6 +360,21 @@ export function useSendService() {
                         }
                     }
 
+                    // Check if Skills is enabled (requires feature flag AND plugin enabled)
+                    const isSkillsOn = featureFlags.skills && (plugins?.some(p => p.id === PluginID.SKILLS) ?? false);
+                    console.log("Skills on: ", isSkillsOn);
+
+                    if (isSkillsOn) {
+                        // Get skills from message data (set by SkillsToggle component)
+                        const selectedSkills = message.data?.skills || [];
+                        const skillSelectionMode = message.data?.skillSelectionMode || 'auto';
+
+                        // Pass skills to backend via options (will be merged later)
+                        chatBody.skills = selectedSkills;
+                        chatBody.skillSelectionMode = skillSelectionMode;
+                        console.log(`Skills: ${selectedSkills.length} skills selected, mode: ${skillSelectionMode}`);
+                    }
+
                     console.log("Adding artifacts to chat body: ", selectedConversation.artifacts);
                     
                     if (isArtifactsOn && selectedConversation.artifacts) {

--- a/services/skillsService.ts
+++ b/services/skillsService.ts
@@ -49,7 +49,16 @@ const sendSkillsRequest = async <T = any>(
 
         if (!response.ok) {
             const errorText = await response.text();
-            throw new Error(`Skills request failed: ${response.status} - ${errorText}`);
+            let userMessage = `Skills request failed (${response.status})`;
+            try {
+                const errorJson = JSON.parse(errorText);
+                if (errorJson.message) {
+                    userMessage = errorJson.message;
+                }
+            } catch {
+                // errorText is not JSON; use generic message
+            }
+            throw new Error(userMessage);
         }
 
         const result = await response.json();

--- a/services/skillsService.ts
+++ b/services/skillsService.ts
@@ -14,6 +14,7 @@ import {
  * Send a skills request to the backend through the chat endpoint
  */
 const sendSkillsRequest = async <T = any>(
+    chatEndpoint: string,
     action: string,
     data: any = {}
 ): Promise<SkillsResponse<T>> => {
@@ -25,7 +26,6 @@ const sendSkillsRequest = async <T = any>(
             throw new Error("No session available");
         }
 
-        const chatEndpoint = process.env.NEXT_PUBLIC_CHAT_ENDPOINT;
         if (!chatEndpoint) {
             throw new Error("Chat endpoint not configured");
         }
@@ -72,63 +72,66 @@ const sendSkillsRequest = async <T = any>(
 /**
  * Create a new skill
  */
-export const createSkill = async (skillData: CreateSkillData): Promise<SkillsResponse<Skill>> => {
-    return sendSkillsRequest<Skill>('create', skillData);
+export const createSkill = async (chatEndpoint: string, skillData: CreateSkillData): Promise<SkillsResponse<Skill>> => {
+    return sendSkillsRequest<Skill>(chatEndpoint, 'create', skillData);
 };
 
 /**
  * Get all skills for the current user
  * @param includeShared Whether to include skills shared with the user
  */
-export const getUserSkills = async (includeShared: boolean = true): Promise<SkillsResponse<Skill[]>> => {
-    return sendSkillsRequest<Skill[]>('list', { includeShared });
+export const getUserSkills = async (chatEndpoint: string, includeShared: boolean = true): Promise<SkillsResponse<Skill[]>> => {
+    return sendSkillsRequest<Skill[]>(chatEndpoint, 'list', { includeShared });
 };
 
 /**
  * Get a single skill by ID
  */
-export const getSkill = async (skillId: string): Promise<SkillsResponse<Skill>> => {
-    return sendSkillsRequest<Skill>('get', { skillId });
+export const getSkill = async (chatEndpoint: string, skillId: string): Promise<SkillsResponse<Skill>> => {
+    return sendSkillsRequest<Skill>(chatEndpoint, 'get', { skillId });
 };
 
 /**
  * Update an existing skill
  */
 export const updateSkill = async (
+    chatEndpoint: string,
     skillId: string,
     updates: UpdateSkillData
 ): Promise<SkillsResponse<Skill>> => {
-    return sendSkillsRequest<Skill>('update', { skillId, updates });
+    return sendSkillsRequest<Skill>(chatEndpoint, 'update', { skillId, updates });
 };
 
 /**
  * Delete a skill
  */
-export const deleteSkill = async (skillId: string): Promise<SkillsResponse<{ success: boolean }>> => {
-    return sendSkillsRequest<{ success: boolean }>('delete', { skillId });
+export const deleteSkill = async (chatEndpoint: string, skillId: string): Promise<SkillsResponse<{ success: boolean }>> => {
+    return sendSkillsRequest<{ success: boolean }>(chatEndpoint, 'delete', { skillId });
 };
 
 /**
  * Share a skill with another user or group
  */
 export const shareSkill = async (
+    chatEndpoint: string,
     skillId: string,
     shareConfig: ShareSkillConfig
 ): Promise<SkillsResponse<SkillShare>> => {
-    return sendSkillsRequest<SkillShare>('share', { skillId, shareConfig });
+    return sendSkillsRequest<SkillShare>(chatEndpoint, 'share', { skillId, shareConfig });
 };
 
 /**
  * Remove a skill share
  */
-export const unshareSkill = async (shareId: string): Promise<SkillsResponse<void>> => {
-    return sendSkillsRequest<void>('unshare', { shareId });
+export const unshareSkill = async (chatEndpoint: string, shareId: string): Promise<SkillsResponse<void>> => {
+    return sendSkillsRequest<void>(chatEndpoint, 'unshare', { shareId });
 };
 
 /**
  * Auto-select skills based on a message and context
  */
 export const autoSelectSkills = async (
+    chatEndpoint: string,
     message: string,
     context: {
         tags?: string[];
@@ -136,24 +139,25 @@ export const autoSelectSkills = async (
         category?: string;
     } = {}
 ): Promise<SkillsResponse<Skill[]>> => {
-    return sendSkillsRequest<Skill[]>('autoSelect', { message, context });
+    return sendSkillsRequest<Skill[]>(chatEndpoint, 'autoSelect', { message, context });
 };
 
 /**
  * Get public skills for discovery
  */
 export const getPublicSkills = async (
+    chatEndpoint: string,
     limit: number = 50,
     tags?: string[]
 ): Promise<SkillsResponse<Skill[]>> => {
-    return sendSkillsRequest<Skill[]>('getPublic', { limit, tags });
+    return sendSkillsRequest<Skill[]>(chatEndpoint, 'getPublic', { limit, tags });
 };
 
 /**
  * Increment usage count for a skill
  */
-export const incrementSkillUsage = async (skillId: string): Promise<SkillsResponse<void>> => {
-    return sendSkillsRequest<void>('incrementUsage', { skillId });
+export const incrementSkillUsage = async (chatEndpoint: string, skillId: string): Promise<SkillsResponse<void>> => {
+    return sendSkillsRequest<void>(chatEndpoint, 'incrementUsage', { skillId });
 };
 
 /**

--- a/services/skillsService.ts
+++ b/services/skillsService.ts
@@ -1,0 +1,236 @@
+// Skills service for managing user skills
+import { getSession } from "next-auth/react";
+import {
+    Skill,
+    SkillsRequest,
+    SkillsResponse,
+    CreateSkillData,
+    UpdateSkillData,
+    ShareSkillConfig,
+    SkillShare
+} from "@/types/skill";
+
+/**
+ * Send a skills request to the backend through the chat endpoint
+ */
+const sendSkillsRequest = async <T = any>(
+    action: string,
+    data: any = {}
+): Promise<SkillsResponse<T>> => {
+    try {
+        const session = await getSession();
+
+        // @ts-ignore
+        if (!session || !session.accessToken) {
+            throw new Error("No session available");
+        }
+
+        const chatEndpoint = process.env.NEXT_PUBLIC_CHAT_ENDPOINT;
+        if (!chatEndpoint) {
+            throw new Error("Chat endpoint not configured");
+        }
+
+        const requestBody: { skillsRequest: SkillsRequest } = {
+            skillsRequest: {
+                action: action as any,
+                data
+            }
+        };
+
+        const response = await fetch(chatEndpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                // @ts-ignore
+                'Authorization': `Bearer ${session.accessToken}`
+            },
+            body: JSON.stringify(requestBody)
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(`Skills request failed: ${response.status} - ${errorText}`);
+        }
+
+        const result = await response.json();
+
+        // Handle nested response format from backend
+        if (result.body && typeof result.body === 'string') {
+            return JSON.parse(result.body);
+        }
+
+        return result;
+    } catch (error) {
+        console.error(`Skills ${action} request failed:`, error);
+        return {
+            success: false,
+            message: error instanceof Error ? error.message : 'Skills operation failed'
+        };
+    }
+};
+
+/**
+ * Create a new skill
+ */
+export const createSkill = async (skillData: CreateSkillData): Promise<SkillsResponse<Skill>> => {
+    return sendSkillsRequest<Skill>('create', skillData);
+};
+
+/**
+ * Get all skills for the current user
+ * @param includeShared Whether to include skills shared with the user
+ */
+export const getUserSkills = async (includeShared: boolean = true): Promise<SkillsResponse<Skill[]>> => {
+    return sendSkillsRequest<Skill[]>('list', { includeShared });
+};
+
+/**
+ * Get a single skill by ID
+ */
+export const getSkill = async (skillId: string): Promise<SkillsResponse<Skill>> => {
+    return sendSkillsRequest<Skill>('get', { skillId });
+};
+
+/**
+ * Update an existing skill
+ */
+export const updateSkill = async (
+    skillId: string,
+    updates: UpdateSkillData
+): Promise<SkillsResponse<Skill>> => {
+    return sendSkillsRequest<Skill>('update', { skillId, updates });
+};
+
+/**
+ * Delete a skill
+ */
+export const deleteSkill = async (skillId: string): Promise<SkillsResponse<{ success: boolean }>> => {
+    return sendSkillsRequest<{ success: boolean }>('delete', { skillId });
+};
+
+/**
+ * Share a skill with another user or group
+ */
+export const shareSkill = async (
+    skillId: string,
+    shareConfig: ShareSkillConfig
+): Promise<SkillsResponse<SkillShare>> => {
+    return sendSkillsRequest<SkillShare>('share', { skillId, shareConfig });
+};
+
+/**
+ * Remove a skill share
+ */
+export const unshareSkill = async (shareId: string): Promise<SkillsResponse<void>> => {
+    return sendSkillsRequest<void>('unshare', { shareId });
+};
+
+/**
+ * Auto-select skills based on a message and context
+ */
+export const autoSelectSkills = async (
+    message: string,
+    context: {
+        tags?: string[];
+        assistantTags?: string[];
+        category?: string;
+    } = {}
+): Promise<SkillsResponse<Skill[]>> => {
+    return sendSkillsRequest<Skill[]>('autoSelect', { message, context });
+};
+
+/**
+ * Get public skills for discovery
+ */
+export const getPublicSkills = async (
+    limit: number = 50,
+    tags?: string[]
+): Promise<SkillsResponse<Skill[]>> => {
+    return sendSkillsRequest<Skill[]>('getPublic', { limit, tags });
+};
+
+/**
+ * Increment usage count for a skill
+ */
+export const incrementSkillUsage = async (skillId: string): Promise<SkillsResponse<void>> => {
+    return sendSkillsRequest<void>('incrementUsage', { skillId });
+};
+
+/**
+ * Parse skill frontmatter from markdown content
+ * Client-side utility for preview/editing
+ */
+export const parseSkillFrontmatter = (content: string): Partial<Skill> => {
+    const frontmatterRegex = /^---\n([\s\S]*?)\n---/;
+    const match = content.match(frontmatterRegex);
+
+    if (!match) return {};
+
+    const yaml = match[1];
+    const result: Partial<Skill> = {};
+
+    try {
+        // Parse name
+        const nameMatch = yaml.match(/name:\s*["']?([^"'\n]+)["']?/);
+        if (nameMatch) result.name = nameMatch[1].trim();
+
+        // Parse description
+        const descMatch = yaml.match(/description:\s*["']?([^"'\n]+)["']?/);
+        if (descMatch) result.description = descMatch[1].trim();
+
+        // Parse tags array
+        const tagsMatch = yaml.match(/tags:\s*\[([^\]]*)\]/);
+        if (tagsMatch) {
+            result.tags = tagsMatch[1]
+                .split(',')
+                .map(t => t.trim().replace(/["']/g, ''))
+                .filter(Boolean);
+        }
+
+        // Parse triggerPhrases array
+        const triggerMatch = yaml.match(/triggerPhrases:\s*\[([^\]]*)\]/);
+        if (triggerMatch) {
+            result.triggerPhrases = triggerMatch[1]
+                .split(',')
+                .map(t => t.trim().replace(/["']/g, ''))
+                .filter(Boolean);
+        }
+
+        // Parse priority
+        const priorityMatch = yaml.match(/priority:\s*(\d+)/);
+        if (priorityMatch) result.priority = parseInt(priorityMatch[1]);
+
+        // Parse category
+        const categoryMatch = yaml.match(/category:\s*["']?([^"'\n]+)["']?/);
+        if (categoryMatch) result.category = categoryMatch[1].trim();
+    } catch (e) {
+        console.error('Error parsing skill frontmatter:', e);
+    }
+
+    return result;
+};
+
+/**
+ * Build skill content from fields (for creating/updating)
+ */
+export const buildSkillContent = (
+    name: string,
+    description: string,
+    tags: string[],
+    triggerPhrases: string[],
+    priority: number,
+    category: string,
+    body: string
+): string => {
+    const frontmatter = `---
+name: "${name}"
+description: "${description}"
+tags: [${tags.map(t => `"${t}"`).join(', ')}]
+triggerPhrases: [${triggerPhrases.map(t => `"${t}"`).join(', ')}]
+priority: ${priority}
+category: "${category}"
+---
+
+`;
+    return frontmatter + body;
+};

--- a/types/assistant.ts
+++ b/types/assistant.ts
@@ -1,5 +1,6 @@
 import {DEFAULT_SYSTEM_PROMPT} from "@/utils/app/const";
 import {AttachedDocument} from "@/types/attacheddocument";
+import { SkillReference, SkillSelectionMode } from "@/types/skill";
 
 
 export enum AssistantProviderID {
@@ -35,6 +36,9 @@ export interface AssistantDefinition {
     data?:{[key:string]:any};
     assistantId?:string;
     groupId?:string;
+    // Skills integration
+    skills?: SkillReference[];
+    skillSelectionMode?: SkillSelectionMode;
 }
 
 export const DEFAULT_ASSISTANT: Assistant = {

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import {WorkflowDefinition} from "@/types/workflow";
 import { Artifact } from './artifacts';
 import { messageTopicData } from './topics';
+import { SkillSelectionMode } from './skill';
 
 export interface Message {
   role: Role;
@@ -129,6 +130,9 @@ export interface ChatBody {
   projectId?: string;
   tools?: any[]; // Tool definitions in OpenAI function format
   enableWebSearch?: boolean; // Enable backend web search tool execution
+  // Skills integration
+  skills?: string[]; // Array of skill IDs to use for this request
+  skillSelectionMode?: SkillSelectionMode; // 'manual', 'auto', or 'hybrid'
 }
 
 export interface Conversation {

--- a/types/plugin.ts
+++ b/types/plugin.ts
@@ -1,4 +1,4 @@
-import { IconRobot, IconChartBar, IconFileSearch, IconLibrary, IconMessageBolt, IconDeviceSdCard, IconWorldSearch, IconPlugConnected } from '@tabler/icons-react';
+import { IconRobot, IconChartBar, IconFileSearch, IconLibrary, IconMessageBolt, IconDeviceSdCard, IconWorldSearch, IconPlugConnected, IconBrain } from '@tabler/icons-react';
 import React from 'react';
 
 // Plugina are on and off features during the conversation chat requests
@@ -21,7 +21,8 @@ export enum PluginID {
   RAG_EVAL = 'rag-eval',
   MEMORY = 'memory',
   WEB_SEARCH = 'web-search',
-  MCP = 'mcp'
+  MCP = 'mcp',
+  SKILLS = 'skills'
 }
 
 export const Plugins: Record<PluginID, Plugin> = {
@@ -77,6 +78,13 @@ export const Plugins: Record<PluginID, Plugin> = {
     title: "Enable MCP (Model Context Protocol) tools. Configure MCP servers in Settings → MCP Servers.",
     default: false,
     iconComponent: IconPlugConnected
+  },
+  [PluginID.SKILLS]: {
+    id: PluginID.SKILLS,
+    name: "Skills",
+    title: "Enable Skills - specialized capabilities that can be auto-selected based on your conversation. Manage skills in Settings → Skills.",
+    default: false,
+    iconComponent: IconBrain
   }
 };
 

--- a/types/skill.ts
+++ b/types/skill.ts
@@ -1,0 +1,146 @@
+// Skill types for the Amplify GenAI application
+
+export interface Skill {
+    id: string;
+    user: string;
+    name: string;
+    description: string;
+    content: string;
+    tags: string[];
+    triggerPhrases: string[];
+    priority: number;
+    category: string;
+    isEnabled: boolean;
+    isPublic: boolean;
+    isShared?: boolean;
+    metadata: SkillMetadata;
+}
+
+export interface SkillMetadata {
+    version: number;
+    createdAt: string;
+    updatedAt: string;
+    usageCount: number;
+    lastUsedAt: string | null;
+}
+
+export interface SkillShare {
+    shareId: string;
+    skillId: string;
+    sharedBy: string;
+    sharedWith: string;
+    shareType: 'user' | 'group' | 'amplify_group';
+    permissions: 'read' | 'read_write';
+    createdAt: string;
+    expiresAt?: string;
+}
+
+export interface SkillReference {
+    skillId: string;
+    isRequired: boolean;
+    name?: string;
+    overrideContent?: string;
+}
+
+export interface ActiveSkill {
+    id: string;
+    name: string;
+    description: string;
+}
+
+export interface SkillsRequest {
+    action: SkillsAction;
+    data?: any;
+}
+
+export type SkillsAction =
+    | 'create'
+    | 'list'
+    | 'get'
+    | 'update'
+    | 'delete'
+    | 'share'
+    | 'unshare'
+    | 'autoSelect'
+    | 'getPublic'
+    | 'incrementUsage';
+
+export interface SkillsResponse<T = any> {
+    success: boolean;
+    data?: T;
+    message?: string;
+}
+
+export type SkillSelectionMode = 'manual' | 'auto' | 'hybrid';
+
+export interface CreateSkillData {
+    name?: string;
+    description?: string;
+    content: string;
+    tags?: string[];
+    triggerPhrases?: string[];
+    priority?: number;
+    category?: string;
+    isPublic?: boolean;
+}
+
+export interface UpdateSkillData {
+    name?: string;
+    description?: string;
+    content?: string;
+    tags?: string[];
+    triggerPhrases?: string[];
+    priority?: number;
+    category?: string;
+    isEnabled?: boolean;
+    isPublic?: boolean;
+}
+
+export interface ShareSkillConfig {
+    sharedWith: string;
+    shareType: 'user' | 'group' | 'amplify_group';
+    permissions?: 'read' | 'read_write';
+    expiresAt?: string;
+}
+
+// Default skill template
+export const DEFAULT_SKILL_TEMPLATE = `---
+name: "My New Skill"
+description: "A helpful skill for specific tasks"
+tags: ["general"]
+triggerPhrases: ["help me with", "I need to"]
+priority: 5
+category: "general"
+---
+
+# Skill Name
+
+Brief description of what this skill helps with.
+
+## Capabilities
+- Capability 1
+- Capability 2
+
+## Guidelines
+1. Guideline 1
+2. Guideline 2
+
+## Examples
+Example usage or output format.
+`;
+
+// Skill categories for organization
+export const SKILL_CATEGORIES = [
+    { id: 'general', name: 'General' },
+    { id: 'coding', name: 'Coding & Development' },
+    { id: 'writing', name: 'Writing & Content' },
+    { id: 'analysis', name: 'Analysis & Research' },
+    { id: 'creative', name: 'Creative' },
+    { id: 'productivity', name: 'Productivity' },
+    { id: 'communication', name: 'Communication' },
+    { id: 'education', name: 'Education & Learning' },
+    { id: 'business', name: 'Business' },
+    { id: 'other', name: 'Other' }
+] as const;
+
+export type SkillCategory = typeof SKILL_CATEGORIES[number]['id'];


### PR DESCRIPTION
## Summary
- Add complete UI for the Skills feature including library management, skill editor, and chat integration
- Users can create, edit, delete, and share skills from a dedicated Skills Library
- Skills can be selected per-conversation via a toggle in the chat input area

## Changes
- **New components:**
  - `components/Skills/SkillsLibrary.tsx` - Full library view with My Skills and Public/Discover tabs
  - `components/Skills/SkillEditor.tsx` - Modal editor for creating/editing skills with metadata fields
  - `components/Skills/SkillSelector.tsx` - Dropdown for selecting skills in conversations
  - `components/Skills/SkillsToggle.tsx` - Chat input toggle for quick skill selection
  - `components/Skills/SkillsSection.tsx` - Skills configuration section in AssistantModal
- **New services:**
  - `services/skillsService.ts` - API client for all skills operations
- **New types:**
  - `types/skill.ts` - TypeScript interfaces and constants for skills
- **Modified files:**
  - `components/Chat/ChatInput.tsx` - Add SkillsToggle component
  - `components/Chatbar/components/ChatbarSettings.tsx` - Add Skills Library button in sidebar
  - `components/Promptbar/components/AssistantModal.tsx` - Add SkillsSection for assistant configuration

## Features
- Skills Library with search, category filtering, and tabbed views (My Skills / Discover)
- Skill Editor with name, description, tags, trigger phrases, priority, and markdown content
- Three-dot menu on skill cards for Edit, Enable/Disable, Delete, and Copy actions
- Scrollable modal for skill editor
- Skills toggle in chat input for per-conversation skill selection