### PR TITLE
feat: add rate limit utilization UI, group rate limits, and MTD cost …

### DIFF
--- a/components/Admin/AdminComponents/Configurations.tsx
+++ b/components/Admin/AdminComponents/Configurations.tsx
@@ -6,7 +6,7 @@ import { IconPlus, IconTrash, IconX, IconCloudFilled, IconMessage, IconCheck, Ic
 import Checkbox from "@/components/ReusableComponents/CheckBox";
 import ExpansionComponent from "@/components/Chat/ExpansionComponent";
 import { RateLimiter } from "@/components/Settings/AccountComponents/RateLimit";
-import { PeriodType, formatRateLimit, rateLimitObj, noRateLimit } from "@/types/rateLimit";
+import { PeriodType, formatRateLimit, formatRateLimits, normalizeRateLimits, rateLimitObj, noRateLimit, RateLimit, RateLimits } from "@/types/rateLimit";
 import { InfoBox } from "@/components/ReusableComponents/InfoBox";
 import Search from "@/components/Search";
 import ActionButton from "@/components/ReusableComponents/ActionButton";
@@ -30,8 +30,8 @@ interface Props {
     
     amplifyUsers: { [key: string]: string };
 
-    rateLimit: {period: PeriodType, rate: string};
-    setRateLimit: (l: {period: PeriodType, rate: string}) => void;
+    rateLimits: RateLimits;
+    setRateLimits: (l: RateLimits) => void;
 
     promptCostAlert: PromptCostAlert;
     setPromptCostAlert: (a: PromptCostAlert) => void;
@@ -53,7 +53,7 @@ interface Props {
 }
 
 export const ConfigurationsTab: FC<Props> = ({admins, setAdmins, ampGroups, setAmpGroups, amplifyUsers, allEmails,
-                                              rateLimit, setRateLimit, promptCostAlert, setPromptCostAlert,
+                                              rateLimits, setRateLimits, promptCostAlert, setPromptCostAlert,
                                               defaultConversationStorage, setDefaultConversationStorage,
                                               emailSupport, setEmailSupport, aiEmailDomain, setAiEmailDomain,
                                               admin_text, updateUnsavedConfigs, onModalStateChange}) => {
@@ -71,8 +71,12 @@ export const ConfigurationsTab: FC<Props> = ({admins, setAdmins, ampGroups, setA
     const [ampGroupSearchTerm, setAmpGroupSearchTerm] = useState<string>(''); 
     const [showAmpGroupSearch, setShowAmpGroupsSearch] = useState<boolean>(true);
     const [editingRateLimit, setEditingRateLimit] = useState<string | null>(null);
-    const [tempRateLimitPeriod, setTempRateLimitPeriod] = useState<PeriodType>('Unlimited');
-    const [tempRateLimitRate, setTempRateLimitRate] = useState<string>('0');  
+    const [tempRateLimits, setTempRateLimits] = useState<RateLimit[]>([]); // working copy for group being edited
+    const [addingGroupLimitRow, setAddingGroupLimitRow] = useState<{period: PeriodType, rate: string} | null>(null);
+    const [addingAdminLimitRow, setAddingAdminLimitRow] = useState<{period: PeriodType, rate: string} | null>(null);
+    const [editingAdminLimitIdx, setEditingAdminLimitIdx] = useState<{idx: number, period: PeriodType, rate: string} | null>(null);
+    const [hoveredAdminLimitIdx, setHoveredAdminLimitIdx] = useState<number | null>(null);
+    const [editingGroupLimitIdx, setEditingGroupLimitIdx] = useState<{idx: number, period: PeriodType, rate: string} | null>(null);
     const [hoveredRateLimit, setHoveredRateLimit] = useState<string | null>(null);
     const [showAddAdminInput, setShowAddAdminInput] = useState<boolean>(false);
     
@@ -103,8 +107,8 @@ export const ConfigurationsTab: FC<Props> = ({admins, setAdmins, ampGroups, setA
         updateUnsavedConfigs(AdminConfigTypes.ADMINS);
     }
 
-    const handleUpdateRateLimit = (updatedRateLimit: {period: PeriodType, rate: string }) => {
-        setRateLimit(updatedRateLimit);
+    const handleUpdateRateLimits = (updatedRateLimits: RateLimits) => {
+        setRateLimits(updatedRateLimits);
         updateUnsavedConfigs(AdminConfigTypes.RATE_LIMIT);
     }
 
@@ -350,17 +354,131 @@ export const ConfigurationsTab: FC<Props> = ({admins, setAdmins, ampGroups, setA
             <div className="admin-style-settings-card">
                 <div className="admin-style-settings-card-header">
                     <div className="flex items-center gap-3 mb-2">
-                        <h3 className="admin-style-settings-card-title">Chat Rate Limit</h3>
-                        <div className="h-[28px] flex flex-row gap-4">
-                            <RateLimiter
-                                period={rateLimit.period}
-                                setPeriod={(p: PeriodType) => handleUpdateRateLimit({...rateLimit, period: p})}
-                                rate={rateLimit.rate ? String(rateLimit.rate) : '0'}
-                                setRate={(r: string) => handleUpdateRateLimit({...rateLimit, rate: r})}
-                            />
-                        </div>
+                        <h3 className="admin-style-settings-card-title">Chat Rate Limits</h3>
+                        <button
+                            title="Add Rate Limit"
+                            disabled={addingAdminLimitRow !== null || rateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null).length >= 4}
+                            className={`flex items-center gap-1 px-2 py-1 rounded border border-neutral-300 dark:border-white/20 text-sm transition-colors ${(addingAdminLimitRow || rateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null).length >= 4) ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-700'}`}
+                            onClick={() => {
+                                const usedPeriods = rateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null).map(l => l.period);
+                                const firstAvailable = (['Monthly', 'Daily', 'Hourly', 'Total'] as PeriodType[]).find(p => !usedPeriods.includes(p)) ?? 'Monthly';
+                                setAddingAdminLimitRow({ period: firstAvailable, rate: '$0.00' });
+                            }}
+                        >
+                            <IconPlus size={14} /> Add Limit
+                        </button>
                     </div>
-                    <p className="admin-style-settings-card-description">Configure rate limiting for chat messages to control usage</p>
+                    <p className="admin-style-settings-card-description">
+                        Configure one or more simultaneous rate limits (e.g. Monthly $300 <strong>AND</strong> Hourly $30). All limits must pass for a user to be allowed.
+                    </p>
+                </div>
+
+                <div className="px-6 pb-4">
+                    {rateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null).length === 0 && !addingAdminLimitRow && (
+                        <span className="text-sm text-neutral-500 dark:text-neutral-400 italic">No limits set — all users are Unlimited</span>
+                    )}
+
+                    <div className="flex flex-wrap items-center gap-2">
+                        {rateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null).map((limit, idx) => (
+                            editingAdminLimitIdx?.idx === idx ? (
+                                <div key={idx} className="flex items-center gap-2">
+                                    <RateLimiter
+                                        period={editingAdminLimitIdx.period}
+                                        setPeriod={(p: PeriodType) => setEditingAdminLimitIdx({ ...editingAdminLimitIdx, period: p })}
+                                        rate={editingAdminLimitIdx.rate}
+                                        setRate={(r: string) => setEditingAdminLimitIdx({ ...editingAdminLimitIdx, rate: r })}
+                                        excludePeriods={rateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null).filter((_, i) => i !== idx).map(l => l.period)}
+                                    />
+                                    <button
+                                        title="Confirm"
+                                        className="text-green-500 hover:text-green-600"
+                                        onClick={() => {
+                                            const updated = rateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null);
+                                            updated[idx] = rateLimitObj(editingAdminLimitIdx.period, editingAdminLimitIdx.rate);
+                                            handleUpdateRateLimits(updated);
+                                            setEditingAdminLimitIdx(null);
+                                        }}
+                                    >
+                                        <IconCheck size={18} />
+                                    </button>
+                                    <button
+                                        title="Cancel"
+                                        className="text-red-400 hover:text-red-600"
+                                        onClick={() => setEditingAdminLimitIdx(null)}
+                                    >
+                                        <IconX size={18} />
+                                    </button>
+                                </div>
+                            ) : (
+                                <div
+                                    key={idx}
+                                    className="flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-neutral-300 dark:border-neutral-600 bg-neutral-100 dark:bg-neutral-700"
+                                    onMouseEnter={() => setHoveredAdminLimitIdx(idx)}
+                                    onMouseLeave={() => setHoveredAdminLimitIdx(null)}
+                                >
+                                    <span className="text-sm font-medium text-neutral-700 dark:text-neutral-200">
+                                        {formatRateLimit(limit)}
+                                    </span>
+                                    {hoveredAdminLimitIdx === idx && (<>
+                                        <button
+                                            title="Edit limit"
+                                            className="text-neutral-400 hover:text-blue-500 transition-colors"
+                                            onClick={() => {
+                                                setAddingAdminLimitRow(null);
+                                                setEditingAdminLimitIdx({ idx, period: limit.period, rate: `$${(limit.rate as number).toFixed(2)}` });
+                                            }}
+                                        >
+                                            <IconEdit size={13} />
+                                        </button>
+                                        <button
+                                            title="Remove limit"
+                                            className="text-neutral-400 hover:text-red-500 transition-colors"
+                                            onClick={() => {
+                                                const active = rateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null);
+                                                active.splice(idx, 1);
+                                                handleUpdateRateLimits(active.length > 0 ? active : []);
+                                            }}
+                                        >
+                                            <IconTrash size={13} />
+                                        </button>
+                                    </>)}
+                                </div>
+                            )
+                        ))}
+
+                        {addingAdminLimitRow && (
+                            <div className="flex items-center gap-2">
+                                <RateLimiter
+                                    period={addingAdminLimitRow.period}
+                                    setPeriod={(p: PeriodType) => setAddingAdminLimitRow({ ...addingAdminLimitRow, period: p })}
+                                    rate={addingAdminLimitRow.rate}
+                                    setRate={(r: string) => setAddingAdminLimitRow({ ...addingAdminLimitRow, rate: r })}
+                                    excludePeriods={rateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null).map(l => l.period)}
+                                />
+                                <button
+                                    title="Confirm"
+                                    className="text-green-500 hover:text-green-600"
+                                    onClick={() => {
+                                        const newLimit = rateLimitObj(addingAdminLimitRow.period, addingAdminLimitRow.rate);
+                                        if (newLimit.period !== 'Unlimited') {
+                                            const existing = rateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null);
+                                            handleUpdateRateLimits([...existing, newLimit]);
+                                        }
+                                        setAddingAdminLimitRow(null);
+                                    }}
+                                >
+                                    <IconCheck size={18} />
+                                </button>
+                                <button
+                                    title="Cancel"
+                                    className="text-red-400 hover:text-red-600"
+                                    onClick={() => setAddingAdminLimitRow(null)}
+                                >
+                                    <IconX size={18} />
+                                </button>
+                            </div>
+                        )}
+                    </div>
                 </div>
             </div>
 
@@ -718,79 +836,179 @@ export const ConfigurationsTab: FC<Props> = ({admins, setAdmins, ampGroups, setA
                                             <td className="text-center border border-neutral-500 px-1 py-2"
                                                 onMouseEnter={() => setHoveredRateLimit(groupName)}
                                                 onMouseLeave={() => setHoveredRateLimit(null)}>
-                                                <div className="flex items-center justify-center">
+                                                <div className="flex flex-col items-center justify-center gap-1">
                                                     {editingRateLimit === groupName ? (
-                                                        <div className="flex flex-row gap-2">
-                                                            <RateLimiter
-                                                                period={tempRateLimitPeriod}
-                                                                setPeriod={setTempRateLimitPeriod}
-                                                                rate={tempRateLimitRate}
-                                                                setRate={setTempRateLimitRate}
-                                                            />
-                                                            <ActionButton
-                                                                title='Confirm Change'
-                                                                id="confirmRateLimitChange"
-                                                                className='text-green-500'
-                                                                handleClick={(e) => {
-                                                                    e.stopPropagation();
-                                                                    const updatedRateLimit = rateLimitObj(tempRateLimitPeriod, tempRateLimitRate);
-                                                                    const updatedGroup = {...group, rateLimit: updatedRateLimit};
-                                                                    handleUpdateAmpGroups({...ampGroups, [groupName]: updatedGroup});
-                                                                    setEditingRateLimit(null);
-                                                                }}
-                                                            >
-                                                                <IconCheck size={18} />
-                                                            </ActionButton>
-                                                            <ActionButton
-                                                                title='Discard Change'
-                                                                id="discardRateLimitChange"
-                                                                className='text-red-500'
-                                                                handleClick={(e) => {
-                                                                    e.stopPropagation();
-                                                                    setEditingRateLimit(null);
-                                                                }}
-                                                            >
-                                                                <IconX size={18} />
-                                                            </ActionButton>
+                                                        // ── EDIT MODE: list editor ──────────────────────────
+                                                        <div className="flex flex-col gap-1.5 w-full px-1">
+                                                            <div className="flex flex-wrap items-center gap-1.5">
+                                                                {tempRateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null).map((limit, idx) => (
+                                                                    editingGroupLimitIdx?.idx === idx ? (
+                                                                        <div key={idx} className="flex items-center gap-1 flex-wrap">
+                                                                            <RateLimiter
+                                                                                period={editingGroupLimitIdx.period}
+                                                                                setPeriod={(p: PeriodType) => setEditingGroupLimitIdx({ ...editingGroupLimitIdx, period: p })}
+                                                                                rate={editingGroupLimitIdx.rate}
+                                                                                setRate={(r: string) => setEditingGroupLimitIdx({ ...editingGroupLimitIdx, rate: r })}
+                                                                                excludePeriods={tempRateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null).filter((_, i) => i !== idx).map(l => l.period)}
+                                                                            />
+                                                                            <button
+                                                                                title="Confirm"
+                                                                                className="text-green-500 hover:text-green-600"
+                                                                                onClick={(e) => {
+                                                                                    e.stopPropagation();
+                                                                                    const updated = [...tempRateLimits];
+                                                                                    updated[idx] = rateLimitObj(editingGroupLimitIdx.period, editingGroupLimitIdx.rate);
+                                                                                    setTempRateLimits(updated);
+                                                                                    setEditingGroupLimitIdx(null);
+                                                                                }}
+                                                                            >
+                                                                                <IconCheck size={15} />
+                                                                            </button>
+                                                                            <button
+                                                                                title="Cancel"
+                                                                                className="text-red-400 hover:text-red-600"
+                                                                                onClick={(e) => { e.stopPropagation(); setEditingGroupLimitIdx(null); }}
+                                                                            >
+                                                                                <IconX size={15} />
+                                                                            </button>
+                                                                        </div>
+                                                                    ) : (
+                                                                    <div key={idx} className="flex items-center gap-1 px-2 py-0.5 rounded-full border border-neutral-400 dark:border-neutral-500 bg-neutral-100 dark:bg-neutral-700">
+                                                                        <span className="text-xs text-neutral-700 dark:text-neutral-200">{formatRateLimit(limit)}</span>
+                                                                        <button
+                                                                            title="Edit"
+                                                                            className="text-neutral-400 hover:text-blue-500"
+                                                                            onClick={(e) => {
+                                                                                e.stopPropagation();
+                                                                                setAddingGroupLimitRow(null);
+                                                                                setEditingGroupLimitIdx({ idx, period: limit.period, rate: `$${(limit.rate as number).toFixed(2)}` });
+                                                                            }}
+                                                                        >
+                                                                            <IconEdit size={11} />
+                                                                        </button>
+                                                                        <button
+                                                                            title="Remove"
+                                                                            className="text-neutral-400 hover:text-red-500"
+                                                                            onClick={(e) => {
+                                                                                e.stopPropagation();
+                                                                                const updated = tempRateLimits.filter((_, i) => i !== idx);
+                                                                                setTempRateLimits(updated);
+                                                                            }}
+                                                                        >
+                                                                            <IconTrash size={11} />
+                                                                        </button>
+                                                                    </div>
+                                                                    )
+                                                                ))}
+                                                            </div>
+
+                                                            {addingGroupLimitRow ? (
+                                                                <div className="flex items-center gap-1 flex-wrap mt-1">
+                                                                    <RateLimiter
+                                                                        period={addingGroupLimitRow.period}
+                                                                        setPeriod={(p: PeriodType) => setAddingGroupLimitRow({ ...addingGroupLimitRow, period: p })}
+                                                                        rate={addingGroupLimitRow.rate}
+                                                                        setRate={(r: string) => setAddingGroupLimitRow({ ...addingGroupLimitRow, rate: r })}
+                                                                        excludePeriods={tempRateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null).map(l => l.period)}
+                                                                    />
+                                                                    <button
+                                                                        title="Confirm add"
+                                                                        className="text-green-500 hover:text-green-600"
+                                                                        onClick={(e) => {
+                                                                            e.stopPropagation();
+                                                                            const newLimit = rateLimitObj(addingGroupLimitRow.period, addingGroupLimitRow.rate);
+                                                                            if (newLimit.period !== 'Unlimited') {
+                                                                                setTempRateLimits(prev => [...prev.filter(l => l.period !== 'Unlimited'), newLimit]);
+                                                                            }
+                                                                            setAddingGroupLimitRow(null);
+                                                                        }}
+                                                                    >
+                                                                        <IconCheck size={15} />
+                                                                    </button>
+                                                                    <button
+                                                                        title="Cancel add"
+                                                                        className="text-red-400 hover:text-red-600"
+                                                                        onClick={(e) => { e.stopPropagation(); setAddingGroupLimitRow(null); }}
+                                                                    >
+                                                                        <IconX size={15} />
+                                                                    </button>
+                                                                </div>
+                                                            ) : (
+                                                                <button
+                                                                    title="Add limit"
+                                                                    disabled={tempRateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null).length >= 4}
+                                                                    className="text-xs text-blue-500 hover:text-blue-600 flex items-center gap-0.5 mt-0.5 disabled:opacity-40 disabled:cursor-not-allowed"
+                                                                    onClick={(e) => {
+                                                                        e.stopPropagation();
+                                                                        const usedPeriods = tempRateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null).map(l => l.period);
+                                                                        const firstAvailable = (['Monthly', 'Daily', 'Hourly', 'Total'] as PeriodType[]).find(p => !usedPeriods.includes(p)) ?? 'Monthly';
+                                                                        setAddingGroupLimitRow({ period: firstAvailable, rate: '$0.00' });
+                                                                    }}
+                                                                >
+                                                                    <IconPlus size={12} /> Add
+                                                                </button>
+                                                            )}
+
+                                                            <div className="flex gap-1.5 mt-1">
+                                                                <ActionButton
+                                                                    title='Save'
+                                                                    id="confirmRateLimitChange"
+                                                                    className='text-green-500'
+                                                                    handleClick={(e) => {
+                                                                        e.stopPropagation();
+                                                                        const savedLimits = tempRateLimits.filter(l => l.period !== 'Unlimited' && l.rate !== null);
+                                                                        const updatedGroup = { ...group, rateLimit: savedLimits.length > 0 ? savedLimits : [noRateLimit] };
+                                                                        handleUpdateAmpGroups({ ...ampGroups, [groupName]: updatedGroup });
+                                                                        setEditingRateLimit(null);
+                                                                        setAddingGroupLimitRow(null);
+                                                                    }}
+                                                                >
+                                                                    <IconCheck size={16} />
+                                                                </ActionButton>
+                                                                <ActionButton
+                                                                    title='Discard'
+                                                                    id="discardRateLimitChange"
+                                                                    className='text-red-500'
+                                                                    handleClick={(e) => {
+                                                                        e.stopPropagation();
+                                                                        setEditingRateLimit(null);
+                                                                        setAddingGroupLimitRow(null);
+                                                                    }}
+                                                                >
+                                                                    <IconX size={16} />
+                                                                </ActionButton>
+                                                            </div>
                                                         </div>
                                                     ) : (
-                                                        <div className="flex items-center justify-center gap-2">
-                                                            <span>{(() => {
-                                                                const rateLimit = group.rateLimit;
-                                                                if (!rateLimit) {
-                                                                    return formatRateLimit(noRateLimit);
-                                                                } else if (typeof rateLimit === 'number') {
-                                                                    // Handle legacy number format
-                                                                    return formatRateLimit(rateLimitObj('Daily', String(rateLimit)));
-                                                                } else {
-                                                                    // Proper RateLimit object
-                                                                    return formatRateLimit(rateLimit);
-                                                                }
-                                                            })()}</span>
+                                                        // ── DISPLAY MODE ────────────────────────────────────
+                                                        <div className="flex items-center justify-center gap-1.5">
+                                                            <span className="text-xs text-center leading-snug">
+                                                                {(() => {
+                                                                    const rl = group.rateLimit;
+                                                                    if (!rl) return 'Unlimited';
+                                                                    if (typeof rl === 'number') return formatRateLimit(rateLimitObj('Daily', String(rl)));
+                                                                    const normalized = normalizeRateLimits(rl);
+                                                                    return formatRateLimits(normalized);
+                                                                })()}
+                                                            </span>
                                                             {hoveredRateLimit === groupName && (
                                                                 <button
                                                                     type="button"
                                                                     id="editRateLimit"
-                                                                    className="text-neutral-400 hover:text-neutral-200"
+                                                                    className="text-neutral-400 hover:text-neutral-200 flex-shrink-0"
                                                                     onClick={() => {
+                                                                        const rl = group.rateLimit;
+                                                                        let normalized: RateLimit[];
+                                                                        if (!rl) normalized = [];
+                                                                        else if (typeof rl === 'number') normalized = [rateLimitObj('Daily', String(rl))];
+                                                                        else normalized = normalizeRateLimits(rl);
+                                                                        setTempRateLimits(normalized.filter(l => l.period !== 'Unlimited' && l.rate !== null));
                                                                         setEditingRateLimit(groupName);
-                                                                        const rateLimit = group.rateLimit;
-                                                                        if (!rateLimit) {
-                                                                            setTempRateLimitPeriod('Unlimited');
-                                                                            setTempRateLimitRate('0');
-                                                                        } else if (typeof rateLimit === 'number') {
-                                                                            // Handle legacy number format
-                                                                            setTempRateLimitPeriod('Daily');
-                                                                            setTempRateLimitRate(String(rateLimit));
-                                                                        } else {
-                                                                            // Proper RateLimit object
-                                                                            setTempRateLimitPeriod(rateLimit.period);
-                                                                            setTempRateLimitRate(rateLimit.rate ? String(rateLimit.rate) : '0');
-                                                                        }
+                                                                        setAddingGroupLimitRow(null);
                                                                     }}
-                                                                    title="Edit Rate Limit"
+                                                                    title="Edit Rate Limits"
                                                                 >
-                                                                    <IconEdit size={18} />
+                                                                    <IconEdit size={16} />
                                                                 </button>
                                                             )}
                                                         </div>

--- a/components/Admin/AdminUI.tsx
+++ b/components/Admin/AdminUI.tsx
@@ -11,7 +11,7 @@ import React from "react";
 import { ActiveTabs } from "../ReusableComponents/ActiveTabs";
 import { OpDef } from "@/types/op";
 import { AMPLIFY_ASSISTANTS_GROUP_NAME } from "@/utils/app/amplifyAssistants";
-import { noRateLimit, PeriodType, RateLimit, rateLimitObj } from "@/types/rateLimit";
+import { noRateLimit, normalizeRateLimits, RateLimit, RateLimits } from "@/types/rateLimit";
 import { adminTabHasChanges} from "@/utils/app/admin";
 import { OpenAIEndpointsTab } from "./AdminComponents/OpenAIEndpoints";
 import { FeatureFlagsTab } from "./AdminComponents/FeatureFlags";
@@ -64,7 +64,7 @@ export const AdminUI: FC<Props> = ({ open, onClose }) => {
     const [admins, setAdmins] = useState<string[]>([]);  
     const [allEmails, setAllEmails] = useState<Array<string> | null>(null);
 
-    const [rateLimit, setRateLimit] = useState<{period: PeriodType, rate: string}>({...noRateLimit, rate: '0'});
+    const [rateLimits, setRateLimits] = useState<RateLimits>([]);
     const [promptCostAlert, setPromptCostAlert] = useState<PromptCostAlert>({isActive:false, alertMessage: '', cost: 0});
     const [emailSupport, setEmailSupport] = useState<EmailSupport>({isActive:false, email:''});
     const [criticalErrorsConfig, setCriticalErrorsConfig] = useState<CriticalErrorsConfig>({isActive:false, email:''});
@@ -191,7 +191,7 @@ export const AdminUI: FC<Props> = ({ open, onClose }) => {
 
                 setAmpGroups(data[AdminConfigTypes.AMPLIFY_GROUPS] || {})
                 setTemplates(data[AdminConfigTypes.PPTX_TEMPLATES] || []);
-                setRateLimit(data[AdminConfigTypes.RATE_LIMIT || rateLimit]);
+                setRateLimits(normalizeRateLimits(data[AdminConfigTypes.RATE_LIMIT]));
                 setPromptCostAlert(data[AdminConfigTypes.PROMPT_COST_ALERT || promptCostAlert]);
                 setDefaultConversationStorage(data[AdminConfigTypes.DEFAULT_CONVERSATION_STORAGE] || defaultConversationStorage);
                 setEmailSupport(data[AdminConfigTypes.EMAIL_SUPPORT || emailSupport]);
@@ -255,7 +255,7 @@ export const AdminUI: FC<Props> = ({ open, onClose }) => {
             case AdminConfigTypes.ADMINS:
                 return admins;
             case AdminConfigTypes.RATE_LIMIT:
-                return rateLimitObj(rateLimit.period, rateLimit.rate);
+                return rateLimits;
             case AdminConfigTypes.PROMPT_COST_ALERT:
                 return {
                     ...promptCostAlert,
@@ -340,7 +340,8 @@ export const AdminUI: FC<Props> = ({ open, onClose }) => {
             case AdminConfigTypes.AMPLIFY_GROUPS:
                 Object.keys(ampGroups).forEach((key: string) => {
                     if (!ampGroups[key].isBillingGroup) ampGroups[key].isBillingGroup = false;
-                    if (!ampGroups[key].rateLimit) ampGroups[key].rateLimit = noRateLimit;
+                    if (!ampGroups[key].rateLimit) ampGroups[key].rateLimit = [noRateLimit];
+                    else ampGroups[key].rateLimit = normalizeRateLimits(ampGroups[key].rateLimit as any);
                     delete ampGroups[key].groupName;
                 });
                 return ampGroups;
@@ -541,7 +542,8 @@ export const AdminUI: FC<Props> = ({ open, onClose }) => {
             homeDispatch({ field: 'webSearchUserMessage', value: webSearchConfig?.webSearchUserMessage?.trim() ?? null});
         });
         saveAction([AdminConfigTypes.USER_DOCUMENTATION_URL], () => homeDispatch({ field: 'userDocumentationUrl', value: userDocumentationUrl}));
-        if (!storageSelection) saveAction([AdminConfigTypes.DEFAULT_CONVERSATION_STORAGE], () => homeDispatch({ field: 'storageSelection', value: defaultConversationStorage})); 
+        saveAction([AdminConfigTypes.RATE_LIMIT], () => homeDispatch({ field: 'adminRateLimits', value: rateLimits }));
+        if (!storageSelection) saveAction([AdminConfigTypes.DEFAULT_CONVERSATION_STORAGE], () => homeDispatch({ field: 'storageSelection', value: defaultConversationStorage}));
     }
 
     const handleSave = async () => {
@@ -703,8 +705,8 @@ export const AdminUI: FC<Props> = ({ open, onClose }) => {
                     ampGroups={ampGroups}
                     setAmpGroups={setAmpGroups}
                     amplifyUsers={amplifyUsers}
-                    rateLimit={rateLimit}
-                    setRateLimit={setRateLimit}
+                    rateLimits={rateLimits}
+                    setRateLimits={setRateLimits}
                     promptCostAlert={promptCostAlert}
                     setPromptCostAlert={setPromptCostAlert}
                     defaultConversationStorage={defaultConversationStorage}
@@ -1120,12 +1122,12 @@ export const AmplifyGroupSelect: React.FC<AmplifyGroupSelectProps> = ({ groups, 
 
 
 
-export interface Amplify_Group { // can be a cognito group 
-    groupName?: string; 
+export interface Amplify_Group { // can be a cognito group
+    groupName?: string;
     members : string[];
     createdBy : string;
     includeFromOtherGroups? : string[]; // if is a cognito group, this will always be Absent
-    rateLimit? : RateLimit;
+    rateLimit? : RateLimit | RateLimit[];  // supports both legacy single and new multi-limit format
     isBillingGroup? : boolean;
 }
 

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -7,6 +7,7 @@ import {
     IconBoxAlignTopFilled,
     IconBoxAlignTopRightFilled,
     IconChevronRight,
+    IconChartHistogram,
 } from '@tabler/icons-react';
 import {
     MutableRefObject,
@@ -27,6 +28,8 @@ import {Conversation, DataSource, Message, MessageType, newMessage} from '@/type
 import {Plugin} from '@/types/plugin';
 
 import HomeContext from '@/pages/api/home/home.context';
+import { getMonthlyLimit, normalizeRateLimits } from '@/types/rateLimit';
+import { RateLimitUtilization } from '@/components/Layout/RateLimitUtilization';
 
 import Spinner from '../Spinner';
 import {ChatInput} from './ChatInput';
@@ -52,7 +55,7 @@ import {ChatRequest, useSendService} from "@/hooks/useChatSendService";
 import {CloudStorage} from './CloudStorage';
 import { getIsLocalStorageSelection } from '@/utils/app/conversationStorage';
 import { getFullTimestamp } from '@/utils/app/date';
-import { doMtdCostOp } from '@/services/mtdCostService'; // MTDCOST
+import { getUserMtdCosts } from '@/services/mtdCostService'; // MTDCOST
 import { GroupTypeSelector } from './GroupTypeSelector';
 import { Artifacts } from '../Artifacts/Artifacts';
 import { downloadDataSourceFile } from '@/utils/app/files';
@@ -102,6 +105,8 @@ export const Chat = memo(({stopConversationRef}: Props) => {
                 isStandalonePromptCreation,
                 promptCostAlertModal,
                 layeredAssistants,
+                adminRateLimits,
+                groupRateLimits,
             },
             setLoadingMessage,
             handleUpdateConversation,
@@ -208,10 +213,27 @@ export const Chat = memo(({stopConversationRef}: Props) => {
         const [variables, setVariables] = useState<string[]>([]);
         const [showScrollDownButton, setShowScrollDownButton] = useState<boolean>(false);
         const [promptTemplate, setPromptTemplate] = useState<Prompt | null>(null);
-        const [mtdCost, setMtdCost] = useState<string>('Loading...'); // MTDCOST
+        const [mtdCost, setMtdCost] = useState<string>('$0.00'); // MTDCOST
+        const [mtdCostNumeric, setMtdCostNumeric] = useState<number>(0);
+        const [mtdDailyCost, setMtdDailyCost] = useState<number>(0);
+        const [mtdHourlyCost, setMtdHourlyCost] = useState<number>(0);
+        const [mtdLoading, setMtdLoading] = useState<boolean>(true);
 
         const [isBarSticky, setIsBarSticky] = useState(getIsBarSticky());
         const [isPillExpanded, setIsPillExpanded] = useState(false);
+        const [showUtilPopover, setShowUtilPopover] = useState(false);
+        const utilPopoverHideTimer = useRef<NodeJS.Timeout | null>(null);
+
+        const showUtil = () => {
+            if (utilPopoverHideTimer.current) clearTimeout(utilPopoverHideTimer.current);
+            setShowUtilPopover(true);
+        };
+        const hideUtil = (collapsePill = false) => {
+            utilPopoverHideTimer.current = setTimeout(() => {
+                setShowUtilPopover(false);
+                if (collapsePill) setIsPillExpanded(false);
+            }, 120);
+        };
 
         const messagesEndRef = useRef<HTMLDivElement>(null);
         const chatContainerRef = useRef<HTMLDivElement>(null);
@@ -222,6 +244,48 @@ export const Chat = memo(({stopConversationRef}: Props) => {
         const [isRenaming, setIsRenaming] = useState<boolean>(false);
 
         const chat_button_blue_color = "text-[#1dbff5] dark:text-[#8edffa]"
+
+        // True only when there is at least one active rate limit to show utilization for
+        const hasActiveLimits = (() => {
+            const personal = defaultAccount?.rateLimit;
+            if (personal && personal.rate !== null && personal.period !== 'Unlimited') return true;
+            if (normalizeRateLimits(adminRateLimits).some(l => l.rate !== null && l.period !== 'Unlimited')) return true;
+            return groupRateLimits.some(g => g.limits.length > 0);
+        })();
+
+        const getMtdPillColor = () => {
+            const personal = defaultAccount?.rateLimit;
+            const effectiveLimit = (personal && personal.rate !== null && personal.period !== 'Unlimited')
+                ? personal
+                : getMonthlyLimit(adminRateLimits ?? []);
+            if (!effectiveLimit || !effectiveLimit.rate || effectiveLimit.rate === 0) return chat_button_blue_color;
+            const pct = (mtdCostNumeric / effectiveLimit.rate) * 100;
+            if (pct >= 80) return 'text-red-500 dark:text-red-400';
+            if (pct >= 50) return 'text-yellow-500 dark:text-yellow-400';
+            return chat_button_blue_color;
+        };
+
+        /** Returns a color class for a specific period's spend against its limit */
+        const getPeriodColor = (period: 'Hourly' | 'Daily' | 'Monthly', spent: number): string => {
+            const personal = defaultAccount?.rateLimit;
+            const allLimits = normalizeRateLimits(adminRateLimits);
+            // Find the matching limit: personal if it matches the period, otherwise admin
+            let limit = null;
+            if (personal && personal.rate !== null && personal.period !== 'Unlimited') {
+                if (personal.period === period || (period === 'Monthly' && personal.period === 'Total')) {
+                    limit = personal;
+                }
+            }
+            if (!limit) {
+                limit = allLimits.find(l => l.rate !== null && l.period !== 'Unlimited' &&
+                    (l.period === period || (period === 'Monthly' && l.period === 'Total'))) ?? null;
+            }
+            if (!limit || !limit.rate || limit.rate === 0) return chat_button_blue_color;
+            const pct = (spent / limit.rate) * 100;
+            if (pct >= 80) return 'text-red-500 dark:text-red-400';
+            if (pct >= 50) return 'text-yellow-500 dark:text-yellow-400';
+            return chat_button_blue_color;
+        };
 
         const [showOnEditMessagePrompt, setShowOnEditMessagePrompt] = useState< {editedMessage: Message, index: number}| null>(null);
         const [showTempEdit, setShowTempEdit] = useState(false);
@@ -1145,17 +1209,26 @@ export const Chat = memo(({stopConversationRef}: Props) => {
                     isFetching = true;
 
                     try {
-                        const result = await doMtdCostOp();
-                        if (result && "MTD Cost" in result && result["MTD Cost"] !== undefined) {
-                            setMtdCost(`$${result["MTD Cost"].toFixed(2)}`);
+                        const result = await getUserMtdCosts();
+                        if (result.success) {
+                            const data = result.data;
+                            setMtdCostNumeric(data.totalCost);
+                            setMtdCost(`$${data.totalCost.toFixed(2)}`);
+                            setMtdDailyCost(data.dailyCost);
+                            const nowUtc = new Date().getUTCHours();
+                            setMtdHourlyCost(data.hourlyCost?.[nowUtc] ?? 0);
                         } else {
+                            setMtdCostNumeric(0);
                             setMtdCost('$0.00');
+                            setMtdDailyCost(0);
+                            setMtdHourlyCost(0);
                         }
                     } catch (error) {
                         console.error("Error fetching MTD cost:", error);
                         setMtdCost('$0.00');
                     } finally {
                         isFetching = false;
+                        setMtdLoading(false);
                     }
                 };
 
@@ -1355,23 +1428,45 @@ export const Chat = memo(({stopConversationRef}: Props) => {
                                         {isBarSticky ? (
                                             // Sticky bar content
                                             <>
-                                                {featureFlags.mtdCost && (
-                                                    <button
-                                                        className="ml-2 mr-1 cursor-pointer hover:opacity-50 flex flex-row items-center"
-                                                        disabled={messageIsStreaming}
-                                                        onClick={(e) => {
-                                                            e.preventDefault();
-                                                            e.stopPropagation();
-                                                            setIsAccountDialogVisible(true);
-                                                        }}
-                                                        title="Month-To-Date Cost"
-                                                        id="month-to-date-cost"
-                                                    >
-                                                        <div className={`text-[0.93rem] ${chat_button_blue_color} mr-1`}>
-                                                            <div className="ml-1">MTD Cost: {mtdCost}</div>
-                                                        </div> {"|"}
-                                                    </button>
-                                                )}          
+                                                {featureFlags.mtdCost && mtdLoading && (
+                                                    <div className="flex flex-row items-center ml-2 mr-1 gap-2 animate-pulse">
+                                                        <div className="h-3 w-14 rounded bg-neutral-300 dark:bg-neutral-600" />
+                                                        <div className="h-3 w-16 rounded bg-neutral-300 dark:bg-neutral-600" />
+                                                        <div className="h-3 w-20 rounded bg-neutral-300 dark:bg-neutral-600" />
+                                                    </div>
+                                                )}
+                                                {featureFlags.mtdCost && !mtdLoading && mtdCostNumeric > 0 && (
+                                                    <div className="flex flex-row items-center ml-2 mr-1 gap-1">
+                                                        <button
+                                                            className={`text-[0.85rem] font-medium ${chat_button_blue_color} hover:opacity-70 transition-opacity cursor-pointer`}
+                                                            onClick={() => window.dispatchEvent(new Event('openCostBreakdown'))}
+                                                            title="View cost breakdown"
+                                                        >
+                                                            MTD Cost: ${mtdCostNumeric.toFixed(2)}
+                                                        </button>
+                                                        {hasActiveLimits && (
+                                                            <div className="relative">
+                                                                <button
+                                                                    className={`cursor-pointer transition-opacity text-black dark:text-white ml-1 ${showUtilPopover ? 'opacity-100' : 'opacity-50 hover:opacity-100'}`}
+                                                                    title="Rate limit utilization"
+                                                                    onMouseEnter={showUtil}
+                                                                    onMouseLeave={() => hideUtil()}
+                                                                >
+                                                                    <IconChartHistogram size={16} />
+                                                                </button>
+                                                                {showUtilPopover && (
+                                                                    <div
+                                                                        className="absolute top-full left-1/2 -translate-x-1/2 mt-2 z-50 bg-white dark:bg-[#2b2c36] border border-neutral-200 dark:border-neutral-600 rounded-xl shadow-xl p-3"
+                                                                        onMouseEnter={showUtil}
+                                                                        onMouseLeave={() => hideUtil()}
+                                                                    >
+                                                                        <RateLimitUtilization variant="mini" />
+                                                                    </div>
+                                                                )}
+                                                            </div>
+                                                        )}
+                                                    </div>
+                                                )}
                                                 <button
                                                     className="font-medium mx-1 cursor-pointer hover:opacity-50 flex flex-row items-center"
                                                     onClick={(e) => {
@@ -1451,7 +1546,7 @@ export const Chat = memo(({stopConversationRef}: Props) => {
                                                 `}
                                                 id="chatUpperMenu"
                                                 onMouseEnter={() => setIsPillExpanded(true)}
-                                                onMouseLeave={() => setIsPillExpanded(false)}
+                                                onMouseLeave={() => { if (!showUtilPopover) setIsPillExpanded(false); hideUtil(false); }}
                                             >
                                                 {/* Always visible - Model name and expand indicator */}
                                                 <button
@@ -1464,19 +1559,30 @@ export const Chat = memo(({stopConversationRef}: Props) => {
                                                     }}
                                                 >
                                                     {selectedAssistant && availableAstModelId(selectedAssistant?.definition?.data?.model)
-                                                                        ? Object.values(availableModels).find(m => m.id === selectedAssistant.definition?.data?.model)?.name 
+                                                                        ? Object.values(availableModels).find(m => m.id === selectedAssistant.definition?.data?.model)?.name
                                                                         : selectedConversation?.model?.name || ''}
-                                                    <IconChevronRight 
-                                                        size={16} 
+                                                    <IconChevronRight
+                                                        size={16}
                                                         className={`ml-2 transition-transform duration-300 ${isPillExpanded ? 'rotate-90' : ''} text-gray-500`}
                                                     />
-                                                                        
                                                 </button>
 
                                                 {/* Expanded content - appears on hover */}
                                                 <div className={`flex flex-row gap-2 items-center transition-all duration-300 overflow-hidden
-                                                        ${isPillExpanded ? 'max-w-[600px] opacity-100 ml-4' : 'max-w-0 opacity-0 ml-0'}
+                                                        ${isPillExpanded ? 'max-w-[800px] opacity-100 ml-4' : 'max-w-0 opacity-0 ml-0'}
                                                     `}>
+
+                                                    {featureFlags.mtdCost && hasActiveLimits && (
+                                                        <button
+                                                            className={`cursor-pointer transition-opacity text-black dark:text-white ${showUtilPopover ? 'opacity-100' : 'opacity-50 hover:opacity-100'}`}
+                                                            title="Rate limit utilization"
+                                                            onMouseEnter={showUtil}
+                                                            onMouseLeave={() => hideUtil()}
+                                                            onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                                                        >
+                                                            <IconChartHistogram size={16} />
+                                                        </button>
+                                                    )}
 
                                                     {renderChatSettings()}
 
@@ -1529,6 +1635,19 @@ export const Chat = memo(({stopConversationRef}: Props) => {
                                                         {isBarSticky ?  <IconBoxAlignTopRightFilled size={18}/> : <IconBoxAlignTopFilled size={18}/>}
                                                     </button>
                                                 </div>
+
+                                                {/* Util popover — rendered outside overflow-hidden so it isn't clipped */}
+                                                {featureFlags.mtdCost && hasActiveLimits && showUtilPopover && (
+                                                    <div
+                                                        className="-mt-2 absolute top-full left-1/2 -translate-x-1/2 z-50 pt-2"
+                                                        onMouseEnter={showUtil}
+                                                        onMouseLeave={() => hideUtil(true)}
+                                                    >
+                                                        <div className="bg-white dark:bg-[#2b2c36] border border-neutral-200 dark:border-neutral-600 rounded-xl shadow-xl p-3">
+                                                            <RateLimitUtilization variant="mini" />
+                                                        </div>
+                                                    </div>
+                                                )}
                                             </div>
                                         )}
                                     </div>

--- a/components/Layout/RateLimitUtilization.tsx
+++ b/components/Layout/RateLimitUtilization.tsx
@@ -1,0 +1,388 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { IconChartHistogram, IconLoader2, IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+import HomeContext from '@/pages/api/home/home.context';
+import { RateLimit, normalizeRateLimits } from '@/types/rateLimit';
+import { getUserMtdCosts, UserMtdCosts } from '@/services/mtdCostService';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const fmt = (n: number) => {
+    if (n === 0) return '$0.00';
+    if (n < 0.01) return '<$0.01';
+    return `$${n.toFixed(2)}`;
+};
+
+function spentForPeriod(limit: RateLimit, mtd: UserMtdCosts): number {
+    switch (limit.period) {
+        case 'Monthly': return mtd.totalCost;
+        case 'Daily':   return mtd.dailyCost;
+        case 'Hourly': {
+            const nowUtc = new Date().getUTCHours();
+            return mtd.hourlyCost?.[nowUtc] ?? 0;
+        }
+        case 'Total':   return mtd.totalCost;
+        default:        return 0;
+    }
+}
+
+function spentForPeriodBreakdown(limit: RateLimit, b: MtdBreakdown): number {
+    switch (limit.period) {
+        case 'Monthly':
+        case 'Total':   return b.monthly;
+        case 'Daily':   return b.daily;
+        case 'Hourly':  return b.hourly;
+        default:        return 0;
+    }
+}
+
+function periodLabel(period: string): string {
+    switch (period) {
+        case 'Monthly': return 'this month';
+        case 'Daily':   return 'today';
+        case 'Hourly':  return 'this hour';
+        case 'Total':   return 'lifetime';
+        default:        return period.toLowerCase();
+    }
+}
+
+function barColor(pct: number): string {
+    if (pct >= 80) return 'bg-red-500';
+    if (pct >= 50) return 'bg-yellow-400';
+    return 'bg-blue-500';
+}
+
+function textColor(pct: number): string {
+    if (pct >= 80) return 'text-red-500 dark:text-red-400';
+    if (pct >= 50) return 'text-yellow-500 dark:text-yellow-400';
+    return 'text-blue-500 dark:text-blue-400';
+}
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+export interface UtilizationEntry {
+    limit: RateLimit;
+    spent: number;
+    pct: number;
+    source: 'personal' | 'admin' | 'group';
+}
+
+export interface MtdBreakdown {
+    hourly: number;
+    daily: number;
+    monthly: number;
+}
+
+interface LimitPage {
+    label: string;
+    source: 'personal' | 'admin' | 'group';
+    entries: UtilizationEntry[];
+}
+
+interface Props {
+    variant: 'mini' | 'full';
+    mtd?: UserMtdCosts | null;
+    mtdBreakdown?: MtdBreakdown;
+    onHasEntries?: (has: boolean) => void;
+}
+
+// ─── entry builder ────────────────────────────────────────────────────────────
+
+function buildEntries(
+    limits: RateLimit[],
+    source: 'personal' | 'admin' | 'group',
+    mtd: UserMtdCosts | null,
+    mtdBreakdown?: MtdBreakdown,
+): UtilizationEntry[] {
+    return limits.map(limit => {
+        const spent = mtd
+            ? spentForPeriod(limit, mtd)
+            : mtdBreakdown
+            ? spentForPeriodBreakdown(limit, mtdBreakdown)
+            : 0;
+        const pct = Math.min((spent / (limit.rate as number)) * 100, 100);
+        return { limit, spent, pct, source };
+    });
+}
+
+// ─── shared page nav (used by both variants) ─────────────────────────────────
+
+interface PageNavProps {
+    pages: LimitPage[];
+    activePage: number;
+    setActivePage: (i: number) => void;
+    compact?: boolean; // true = mini style, false = full style
+}
+
+const PageNav: React.FC<PageNavProps> = ({ pages, activePage, setActivePage, compact = false }) => {
+    if (pages.length <= 1) return null;
+    const btnBase = compact
+        ? 'p-0.5 rounded disabled:opacity-30 transition-colors text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-200'
+        : 'p-0.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 disabled:opacity-30 transition-colors';
+    return (
+        <div className="flex items-center gap-1">
+            <button
+                onClick={() => setActivePage(Math.max(0, activePage - 1))}
+                disabled={activePage === 0}
+                className={btnBase}
+            >
+                <IconChevronLeft size={compact ? 11 : 13} className="text-neutral-500" />
+            </button>
+            {pages.map((page, i) => (
+                <button
+                    key={i}
+                    onClick={() => setActivePage(i)}
+                    className={`${compact ? 'px-2 py-0.5 text-[10px]' : 'px-2.5 py-0.5 text-xs'} rounded-full font-medium whitespace-nowrap transition-colors ${
+                        i === activePage
+                            ? 'bg-blue-500 text-white'
+                            : 'bg-neutral-200 dark:bg-neutral-700 text-neutral-500 dark:text-neutral-400 hover:bg-neutral-300 dark:hover:bg-neutral-600'
+                    }`}
+                >
+                    {page.label}
+                </button>
+            ))}
+            <button
+                onClick={() => setActivePage(Math.min(pages.length - 1, activePage + 1))}
+                disabled={activePage === pages.length - 1}
+                className={btnBase}
+            >
+                <IconChevronRight size={compact ? 11 : 13} className="text-neutral-500" />
+            </button>
+        </div>
+    );
+};
+
+// ─── component ───────────────────────────────────────────────────────────────
+
+export const RateLimitUtilization: React.FC<Props> = ({ variant, mtd: externalMtd, mtdBreakdown, onHasEntries }) => {
+    const {
+        state: { defaultAccount, adminRateLimits, groupRateLimits },
+    } = useContext(HomeContext);
+
+    const [mtd, setMtd] = useState<UserMtdCosts | null>(externalMtd ?? null);
+    const [loading, setLoading] = useState(!externalMtd && !mtdBreakdown);
+    const [activePage, setActivePage] = useState(0);
+
+    useEffect(() => {
+        if (externalMtd !== undefined) {
+            setMtd(externalMtd);
+            setLoading(false);
+            return;
+        }
+        if (mtdBreakdown !== undefined) {
+            setLoading(false);
+            return;
+        }
+        let cancelled = false;
+        (async () => {
+            setLoading(true);
+            const result = await getUserMtdCosts();
+            if (!cancelled) {
+                setMtd(result.success ? result.data : null);
+                setLoading(false);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [externalMtd, mtdBreakdown]);
+
+    // ── Build pages (personal-first: if personal exists, only show personal) ──
+    const personal = defaultAccount?.rateLimit;
+    const hasPersonal = !!(personal && personal.rate !== null && personal.period !== 'Unlimited');
+
+    const pages: LimitPage[] = [];
+
+    if (hasPersonal) {
+        // Personal limit is the only one that matters — backend checks this first and stops
+        pages.push({
+            label: 'My Limit',
+            source: 'personal',
+            entries: buildEntries([personal!], 'personal', mtd, mtdBreakdown),
+        });
+    } else {
+        const activeAdminLimits = normalizeRateLimits(adminRateLimits).filter(
+            l => l.rate !== null && l.period !== 'Unlimited'
+        );
+        if (activeAdminLimits.length > 0) {
+            pages.push({
+                label: 'Admin',
+                source: 'admin',
+                entries: buildEntries(activeAdminLimits, 'admin', mtd, mtdBreakdown),
+            });
+        }
+        for (const group of (groupRateLimits ?? [])) {
+            const activeLimits = group.limits.filter(l => l.rate !== null && l.period !== 'Unlimited');
+            if (activeLimits.length > 0) {
+                pages.push({
+                    label: group.groupName,
+                    source: 'group',
+                    entries: buildEntries(activeLimits, 'group', mtd, mtdBreakdown),
+                });
+            }
+        }
+    }
+
+    useEffect(() => {
+        if (activePage >= pages.length && pages.length > 0) setActivePage(pages.length - 1);
+    }, [pages.length]);
+
+    const allEntries = pages.flatMap(p => p.entries);
+
+    useEffect(() => {
+        onHasEntries?.(allEntries.length > 0);
+    }, [allEntries.length]);
+
+    if (!loading && allEntries.length === 0) return null;
+
+    // ── Shared spend values ───────────────────────────────────────────────────
+    const hourlySpend  = mtdBreakdown?.hourly  ?? (mtd ? (mtd.hourlyCost?.[new Date().getUTCHours()] ?? 0) : 0);
+    const dailySpend   = mtdBreakdown?.daily   ?? (mtd?.dailyCost  ?? 0);
+    const monthlySpend = mtdBreakdown?.monthly ?? (mtd?.totalCost  ?? 0);
+
+    function spendPct(period: 'Hourly' | 'Daily' | 'Monthly'): number | null {
+        const matchPeriod = period === 'Monthly' ? ['Monthly', 'Total'] : [period];
+        const entry = allEntries.find(e => matchPeriod.includes(e.limit.period));
+        return entry ? entry.pct : null;
+    }
+    const hourlyColor  = (() => { const p = spendPct('Hourly');  return p !== null ? textColor(p) : 'text-neutral-500 dark:text-neutral-400'; })();
+    const dailyColor   = (() => { const p = spendPct('Daily');   return p !== null ? textColor(p) : 'text-neutral-500 dark:text-neutral-400'; })();
+    const monthlyColor = (() => { const p = spendPct('Monthly'); return p !== null ? textColor(p) : 'text-neutral-500 dark:text-neutral-400'; })();
+
+    const currentPage = pages[Math.min(activePage, pages.length - 1)];
+
+    // ── MINI variant ─────────────────────────────────────────────────────────
+    if (variant === 'mini') {
+        return (
+            <div className="min-w-[200px] max-w-[260px]">
+                {loading ? (
+                    <div className="flex items-center gap-1.5 text-xs text-neutral-400 py-1">
+                        <IconLoader2 size={12} className="animate-spin" />
+                        <span>Loading…</span>
+                    </div>
+                ) : (
+                    <div className="space-y-2.5">
+                        {/* Spend row */}
+                        <div className="flex items-center justify-between gap-3 pb-2 border-b border-neutral-200 dark:border-neutral-600">
+                            <div className="flex flex-col items-center gap-0.5">
+                                <span className="text-[10px] text-neutral-400 uppercase tracking-wide">Hourly</span>
+                                <span className={`text-[12px] font-bold tabular-nums ${hourlyColor}`}>{fmt(hourlySpend)}</span>
+                            </div>
+                            <div className="w-px h-6 bg-neutral-200 dark:bg-neutral-600" />
+                            <div className="flex flex-col items-center gap-0.5">
+                                <span className="text-[10px] text-neutral-400 uppercase tracking-wide">Daily</span>
+                                <span className={`text-[12px] font-bold tabular-nums ${dailyColor}`}>{fmt(dailySpend)}</span>
+                            </div>
+                            <div className="w-px h-6 bg-neutral-200 dark:bg-neutral-600" />
+                            <div className="flex flex-col items-center gap-0.5">
+                                <span className="text-[10px] text-neutral-400 uppercase tracking-wide">Monthly</span>
+                                <span className={`text-[12px] font-bold tabular-nums ${monthlyColor}`}>{fmt(monthlySpend)}</span>
+                            </div>
+                        </div>
+
+                        {/* Compact page nav */}
+                        {pages.length > 1 && (
+                            <div className="flex items-center justify-between">
+                                <span className="text-[10px] text-neutral-400 uppercase tracking-wide">Limits</span>
+                                <PageNav pages={pages} activePage={activePage} setActivePage={setActivePage} compact={true} />
+                            </div>
+                        )}
+
+                        {/* Current page's utilization bars */}
+                        {currentPage?.entries.map(({ limit, spent, pct }, i) => (
+                            <div key={i}>
+                                <div className="flex justify-between items-baseline mb-1">
+                                    <span className="text-[11px] font-medium text-neutral-600 dark:text-neutral-300">
+                                        {limit.period} Limit
+                                    </span>
+                                    <span className={`text-[11px] font-bold tabular-nums ${textColor(pct)}`}>
+                                        {fmt(spent)} / {fmt(limit.rate as number)}
+                                    </span>
+                                </div>
+                                <div className="w-full bg-neutral-200 dark:bg-neutral-600 rounded-full h-1.5">
+                                    <div
+                                        className={`h-1.5 rounded-full transition-all duration-500 ${barColor(pct)}`}
+                                        style={{ width: `${pct}%` }}
+                                    />
+                                </div>
+                                <div className={`text-right text-[10px] mt-0.5 ${textColor(pct)}`}>
+                                    {pct.toFixed(0)}% {periodLabel(limit.period)}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    // ── FULL variant ─────────────────────────────────────────────────────────
+    return (
+        <div className="rounded-xl bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700 p-6">
+
+            {/* Header with page nav on the right */}
+            <div className="flex items-center gap-2 mb-5">
+                <IconChartHistogram size={16} className="text-neutral-400" />
+                <span className="text-sm font-semibold text-neutral-700 dark:text-neutral-200">
+                    Rate Limit Utilization
+                </span>
+                <div className="ml-auto">
+                    <PageNav pages={pages} activePage={activePage} setActivePage={setActivePage} compact={false} />
+                </div>
+            </div>
+
+            {loading ? (
+                <div className="flex justify-center py-8">
+                    <IconLoader2 size={28} className="animate-spin text-blue-500" />
+                </div>
+            ) : (
+                <>
+                    {/* Spend summary row */}
+                    <div className="flex items-center justify-around mb-5 pb-4 border-b border-neutral-200 dark:border-neutral-700">
+                        <div className="flex flex-col items-center gap-1">
+                            <span className="text-xs text-neutral-400 uppercase tracking-wide">Hourly</span>
+                            <span className={`text-base font-bold tabular-nums ${hourlyColor}`}>{fmt(hourlySpend)}</span>
+                        </div>
+                        <div className="w-px h-8 bg-neutral-200 dark:bg-neutral-700" />
+                        <div className="flex flex-col items-center gap-1">
+                            <span className="text-xs text-neutral-400 uppercase tracking-wide">Daily</span>
+                            <span className={`text-base font-bold tabular-nums ${dailyColor}`}>{fmt(dailySpend)}</span>
+                        </div>
+                        <div className="w-px h-8 bg-neutral-200 dark:bg-neutral-700" />
+                        <div className="flex flex-col items-center gap-1">
+                            <span className="text-xs text-neutral-400 uppercase tracking-wide">Monthly</span>
+                            <span className={`text-base font-bold tabular-nums ${monthlyColor}`}>{fmt(monthlySpend)}</span>
+                        </div>
+                    </div>
+
+                    {/* Active page entries */}
+                    {currentPage && (
+                        <div className="space-y-5">
+                            {currentPage.entries.map(({ limit, spent, pct }, i) => (
+                                <div key={i}>
+                                    <div className="flex justify-between items-baseline mb-1.5">
+                                        <span className="text-sm font-semibold text-neutral-700 dark:text-neutral-300">
+                                            {limit.period} Limit
+                                        </span>
+                                        <span className={`text-sm font-bold tabular-nums ${textColor(pct)}`}>
+                                            {fmt(spent)} <span className="font-normal text-neutral-400">/ {fmt(limit.rate as number)}</span>
+                                        </span>
+                                    </div>
+                                    <div className="w-full bg-neutral-200 dark:bg-neutral-700 rounded-full h-2.5">
+                                        <div
+                                            className={`h-2.5 rounded-full transition-all duration-700 ${barColor(pct)}`}
+                                            style={{ width: `${pct}%` }}
+                                        />
+                                    </div>
+                                    <div className="flex justify-between mt-1">
+                                        <span className="text-xs text-neutral-400">{periodLabel(limit.period)}</span>
+                                        <span className={`text-xs font-medium ${textColor(pct)}`}>
+                                            {pct.toFixed(1)}% used
+                                        </span>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </>
+            )}
+        </div>
+    );
+};

--- a/components/Layout/UserCostBreakdownModal.tsx
+++ b/components/Layout/UserCostBreakdownModal.tsx
@@ -138,7 +138,7 @@ export const UserCostBreakdownModal: React.FC<Props> = ({ email, onClose }) => {
                                         <div className="flex items-center justify-between mb-5">
                                             <div className="flex items-center gap-2">
                                                 <IconClock size={16} className="text-neutral-400" />
-                                                <span className="text-sm font-semibold text-neutral-700 dark:text-neutral-200">Today's Hourly Activity</span>
+                                                <span className="text-sm font-semibold text-neutral-700 dark:text-neutral-200">Today&apos;s Hourly Activity</span>
                                             </div>
                                             <span className="text-xs text-neutral-400">local time · hover for $</span>
                                         </div>

--- a/components/Layout/UserCostBreakdownModal.tsx
+++ b/components/Layout/UserCostBreakdownModal.tsx
@@ -1,0 +1,310 @@
+import React, { useEffect, useState } from 'react';
+import {
+    IconX,
+    IconTrendingUp,
+    IconTrendingDown,
+    IconMinus,
+    IconLoader2,
+    IconCreditCard,
+    IconClock,
+    IconChartBar,
+    IconWallet,
+} from '@tabler/icons-react';
+import { getUserMtdCosts, getUserCostHistory, UserMtdCosts, UserCostHistory } from '@/services/mtdCostService';
+import { RateLimitUtilization } from './RateLimitUtilization';
+
+interface Props {
+    email: string;
+    onClose: () => void;
+}
+
+const fmt = (n: number) => `$${n.toFixed(2)}`;
+
+const utcToLocalHours = (hourlyCost: number[]): { hour: number; label: string; cost: number }[] => {
+    const offsetMinutes = new Date().getTimezoneOffset();
+    const offsetHours = offsetMinutes / 60;
+    return Array.from({ length: 24 }, (_, utcHour) => {
+        const localHour = ((utcHour - offsetHours) % 24 + 24) % 24;
+        const label = localHour === 0 ? '12a' : localHour < 12 ? `${localHour}a` : localHour === 12 ? '12p' : `${localHour - 12}p`;
+        return { hour: localHour, label, cost: hourlyCost[utcHour] || 0 };
+    }).sort((a, b) => a.hour - b.hour);
+};
+
+const currentLocalHour = () => new Date().getHours();
+
+export const UserCostBreakdownModal: React.FC<Props> = ({ email, onClose }) => {
+    const [mtd, setMtd] = useState<UserMtdCosts | null>(null);
+    const [history, setHistory] = useState<UserCostHistory | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const load = async () => {
+            const [mtdResult, histResult] = await Promise.all([
+                getUserMtdCosts(),
+                getUserCostHistory(email, 6),
+            ]);
+            if (mtdResult.success) setMtd(mtdResult.data);
+            if (histResult.success) setHistory(histResult.data ?? null);
+            setLoading(false);
+        };
+        load();
+    }, [email]);
+
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [onClose]);
+
+    const hourlyData = mtd ? utcToLocalHours(mtd.hourlyCost) : [];
+    const maxHourlyCost = Math.max(...hourlyData.map(h => h.cost), 0.01);
+    const nowHour = currentLocalHour();
+
+    const trend = history?.summary?.trend;
+    const TrendIcon = trend?.direction === 'up' ? IconTrendingUp : trend?.direction === 'down' ? IconTrendingDown : IconMinus;
+    const trendColor = trend?.direction === 'up' ? 'text-red-500' : trend?.direction === 'down' ? 'text-green-500' : 'text-neutral-400';
+
+    const historyBars = history?.history?.slice(0, 6).reverse() ?? [];
+    const maxHistoryCost = Math.max(...historyBars.map(m => m.totalCost), 0.01);
+    const maxAccountCost = Math.max(...(mtd?.accounts?.map(a => a.totalCost) ?? []), 0.01);
+
+    return (
+        <div
+            className="fixed inset-0 z-[10000] flex items-center justify-center p-6"
+            onClick={onClose}
+        >
+            <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
+
+            <div
+                className="relative w-[95vw] max-w-7xl max-h-[90vh] flex flex-col bg-white dark:bg-[#2b2c36] rounded-xl shadow-2xl border border-neutral-200 dark:border-neutral-600 overflow-hidden"
+                onClick={e => e.stopPropagation()}
+            >
+                {/* Header */}
+                <div className="flex items-center justify-between px-8 py-5 border-b border-neutral-200 dark:border-neutral-600 shrink-0">
+                    <div className="flex items-center gap-3">
+                        <div className="p-2 rounded-lg bg-blue-50 dark:bg-blue-900/30">
+                            <IconWallet size={22} className="text-blue-500 dark:text-blue-400" />
+                        </div>
+                        <div>
+                            <div className="text-xl font-bold text-neutral-900 dark:text-neutral-100">Cost Breakdown</div>
+                            <div className="text-sm text-neutral-400 dark:text-neutral-500">{email}</div>
+                        </div>
+                    </div>
+                    <button
+                        onClick={onClose}
+                        className="p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
+                    >
+                        <IconX size={20} className="text-neutral-500 dark:text-neutral-400" />
+                    </button>
+                </div>
+
+                {/* Scrollable body */}
+                <div className="flex-1 overflow-y-auto px-8 py-6 space-y-6">
+                    {loading ? (
+                        <div className="flex flex-col items-center justify-center py-32 gap-4">
+                            <IconLoader2 size={40} className="animate-spin text-blue-500" />
+                            <div className="text-base text-neutral-400">Loading your usage data…</div>
+                        </div>
+                    ) : (
+                        <>
+                            {/* Summary Cards */}
+                            <div className="grid grid-cols-3 gap-5">
+                                {[
+                                    { label: 'Today', value: mtd?.dailyCost ?? 0, sub: 'current day spend', icon: <IconClock size={20} />, colorClass: 'text-blue-500 dark:text-blue-400', bgClass: 'bg-blue-50 dark:bg-blue-900/20 border-blue-100 dark:border-blue-800/40' },
+                                    { label: 'Prior Days', value: mtd?.monthlyCost ?? 0, sub: 'carried this month', icon: <IconCreditCard size={20} />, colorClass: 'text-indigo-500 dark:text-indigo-400', bgClass: 'bg-indigo-50 dark:bg-indigo-900/20 border-indigo-100 dark:border-indigo-800/40' },
+                                    { label: 'MTD Total', value: mtd?.totalCost ?? 0, sub: 'month-to-date', icon: <IconWallet size={20} />, colorClass: 'text-violet-500 dark:text-violet-400', bgClass: 'bg-violet-50 dark:bg-violet-900/20 border-violet-100 dark:border-violet-800/40' },
+                                ].map(({ label, value, sub, icon, colorClass, bgClass }) => (
+                                    <div key={label} className={`rounded-xl border p-6 flex flex-col gap-2 ${bgClass}`}>
+                                        <div className={`flex items-center gap-2 text-sm font-semibold ${colorClass}`}>
+                                            {icon}
+                                            <span>{label}</span>
+                                        </div>
+                                        <div className="text-4xl font-bold text-neutral-900 dark:text-neutral-100 tabular-nums mt-1">
+                                            {fmt(value)}
+                                        </div>
+                                        <div className="text-xs text-neutral-400 dark:text-neutral-500">{sub}</div>
+                                    </div>
+                                ))}
+                            </div>
+
+                            {/* Two-column layout */}
+                            <div className="grid grid-cols-2 gap-5">
+
+                                {/* LEFT: Hourly + History */}
+                                <div className="space-y-5">
+
+                                    {/* Hourly Activity */}
+                                    <div className="rounded-xl bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700 p-6">
+                                        <div className="flex items-center justify-between mb-5">
+                                            <div className="flex items-center gap-2">
+                                                <IconClock size={16} className="text-neutral-400" />
+                                                <span className="text-sm font-semibold text-neutral-700 dark:text-neutral-200">Today's Hourly Activity</span>
+                                            </div>
+                                            <span className="text-xs text-neutral-400">local time · hover for $</span>
+                                        </div>
+                                        {(mtd?.dailyCost ?? 0) === 0 ? (
+                                            <div className="text-center text-sm text-neutral-400 py-12">No activity recorded today</div>
+                                        ) : (
+                                            <>
+                                                <div className="flex items-end gap-0.5 h-36">
+                                                    {hourlyData.map(({ hour, label, cost }) => {
+                                                        const heightPct = (cost / maxHourlyCost) * 100;
+                                                        const isCurrent = hour === nowHour;
+                                                        const hasActivity = cost > 0;
+                                                        return (
+                                                            <div key={hour} className="group relative flex-1 flex flex-col items-center justify-end h-full">
+                                                                <div
+                                                                    className={`w-full rounded-sm transition-all duration-300 ${
+                                                                        isCurrent
+                                                                            ? 'bg-blue-500 dark:bg-blue-400'
+                                                                            : hasActivity
+                                                                            ? 'bg-blue-300 dark:bg-blue-600 group-hover:bg-blue-400 dark:group-hover:bg-blue-500'
+                                                                            : 'bg-neutral-200 dark:bg-neutral-700'
+                                                                    }`}
+                                                                    style={{ height: hasActivity ? `${Math.max(heightPct, 4)}%` : '2px' }}
+                                                                />
+                                                                {hasActivity && (
+                                                                    <div className="absolute bottom-full mb-1.5 left-1/2 -translate-x-1/2 hidden group-hover:flex flex-col items-center z-10 pointer-events-none">
+                                                                        <div className="bg-neutral-900 dark:bg-neutral-100 text-white dark:text-neutral-900 text-xs font-medium px-2 py-1 rounded whitespace-nowrap shadow-lg">
+                                                                            {label} · {fmt(cost)}
+                                                                        </div>
+                                                                        <div className="w-2 h-2 bg-neutral-900 dark:bg-neutral-100 rotate-45 -mt-1" />
+                                                                    </div>
+                                                                )}
+                                                            </div>
+                                                        );
+                                                    })}
+                                                </div>
+                                                <div className="flex justify-between mt-2">
+                                                    {['12a', '3a', '6a', '9a', '12p', '3p', '6p', '9p', 'now'].map((l, i) => (
+                                                        <span key={i} className={`text-[10px] ${l === 'now' ? 'text-blue-400 font-semibold' : 'text-neutral-400'}`}>{l}</span>
+                                                    ))}
+                                                </div>
+                                            </>
+                                        )}
+                                    </div>
+
+                                    {/* 6-Month History */}
+                                    {historyBars.length > 0 && (
+                                        <div className="rounded-xl bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700 p-6">
+                                            <div className="flex items-center justify-between mb-5">
+                                                <div className="flex items-center gap-2">
+                                                    <IconChartBar size={16} className="text-neutral-400" />
+                                                    <span className="text-sm font-semibold text-neutral-700 dark:text-neutral-200">6-Month History</span>
+                                                </div>
+                                                {trend && trend.direction !== 'flat' && (
+                                                    <div className={`flex items-center gap-1.5 text-xs font-medium ${trendColor}`}>
+                                                        <TrendIcon size={14} />
+                                                        <span>{trend.percentage.toFixed(0)}% vs last month</span>
+                                                    </div>
+                                                )}
+                                            </div>
+                                            <div className="flex items-end gap-4 h-36">
+                                                {historyBars.map((month) => {
+                                                    const heightPct = (month.totalCost / maxHistoryCost) * 100;
+                                                    return (
+                                                        <div key={month.month} className="group relative flex-1 flex flex-col items-center justify-end h-full">
+                                                            <div
+                                                                className={`w-full rounded-t transition-all duration-500 ${
+                                                                    month.isCurrent
+                                                                        ? 'bg-blue-500 dark:bg-blue-400'
+                                                                        : 'bg-neutral-300 dark:bg-neutral-600 group-hover:bg-neutral-400 dark:group-hover:bg-neutral-500'
+                                                                }`}
+                                                                style={{ height: `${Math.max(heightPct, 3)}%` }}
+                                                            />
+                                                            <div className="absolute bottom-full mb-1.5 left-1/2 -translate-x-1/2 hidden group-hover:flex flex-col items-center z-10 pointer-events-none">
+                                                                <div className="bg-neutral-900 dark:bg-neutral-100 text-white dark:text-neutral-900 text-xs font-medium px-2 py-1 rounded whitespace-nowrap shadow-lg">
+                                                                    {month.displayMonth} · {fmt(month.totalCost)}
+                                                                </div>
+                                                                <div className="w-2 h-2 bg-neutral-900 dark:bg-neutral-100 rotate-45 -mt-1" />
+                                                            </div>
+                                                        </div>
+                                                    );
+                                                })}
+                                            </div>
+                                            <div className="flex gap-4 mt-2">
+                                                {historyBars.map((month) => (
+                                                    <span key={month.month} className={`flex-1 text-center text-xs ${month.isCurrent ? 'text-blue-500 dark:text-blue-400 font-semibold' : 'text-neutral-400'}`}>
+                                                        {month.displayMonth.split(' ')[0]}
+                                                    </span>
+                                                ))}
+                                            </div>
+                                            {history?.summary && (
+                                                <div className="mt-4 pt-4 border-t border-neutral-200 dark:border-neutral-700 grid grid-cols-2 gap-4">
+                                                    <div>
+                                                        <div className="text-xs text-neutral-400 mb-1">Avg / month</div>
+                                                        <div className="text-xl font-bold text-neutral-800 dark:text-neutral-200 tabular-nums">{fmt(history.summary.avgMonthlySpend)}</div>
+                                                    </div>
+                                                    <div>
+                                                        <div className="text-xs text-neutral-400 mb-1">All-time ({history.summary.monthCount} mo)</div>
+                                                        <div className="text-xl font-bold text-neutral-800 dark:text-neutral-200 tabular-nums">{fmt(history.summary.totalSpendAllTime)}</div>
+                                                    </div>
+                                                </div>
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
+
+                                {/* RIGHT: Account Breakdown + Rate Limit Utilization */}
+                                <div className="space-y-5">
+                                <RateLimitUtilization variant="full" mtd={mtd} />
+                                {mtd && mtd.accounts.length > 0 && (
+                                    <div className="rounded-xl bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700 p-6 flex flex-col">
+                                        <div className="flex items-center justify-between mb-5 shrink-0">
+                                            <div className="flex items-center gap-2">
+                                                <IconCreditCard size={16} className="text-neutral-400" />
+                                                <span className="text-sm font-semibold text-neutral-700 dark:text-neutral-200">Account Breakdown</span>
+                                            </div>
+                                            <span className="text-xs text-neutral-400">{mtd.accounts.length} account{mtd.accounts.length !== 1 ? 's' : ''}</span>
+                                        </div>
+                                        <div className="space-y-5 pr-1 overflow-y-auto max-h-[250px]">
+                                            {mtd.accounts.map((acc) => {
+                                                const barPct = (acc.totalCost / maxAccountCost) * 100;
+                                                const label = acc.accountInfo?.split('#')[0] ?? acc.accountInfo;
+                                                const keyId = acc.accountInfo?.split('#')[1];
+                                                return (
+                                                    <div key={acc.accountInfo}>
+                                                        <div className="flex justify-between items-start mb-2">
+                                                            <div className="flex flex-col min-w-0 mr-3">
+                                                                <span className="text-sm font-medium text-neutral-700 dark:text-neutral-300 truncate" title={acc.accountInfo}>
+                                                                    {label}
+                                                                </span>
+                                                                {keyId && keyId !== 'NA' && (
+                                                                    <span className="text-[10px] text-neutral-400 truncate font-mono mt-0.5">{keyId}</span>
+                                                                )}
+                                                            </div>
+                                                            <span className="text-sm font-bold text-neutral-900 dark:text-neutral-100 tabular-nums shrink-0">
+                                                                {fmt(acc.totalCost)}
+                                                            </span>
+                                                        </div>
+                                                        <div className="w-full bg-neutral-200 dark:bg-neutral-700 rounded-full h-1.5 mb-2">
+                                                            <div
+                                                                className="h-1.5 rounded-full bg-indigo-400 dark:bg-indigo-500 transition-all duration-500"
+                                                                style={{ width: `${barPct}%` }}
+                                                            />
+                                                        </div>
+                                                        <div className="flex gap-5">
+                                                            <span className="text-xs text-neutral-400">Today <span className="text-neutral-600 dark:text-neutral-300 font-semibold">{fmt(acc.dailyCost)}</span></span>
+                                                            <span className="text-xs text-neutral-400">Month <span className="text-neutral-600 dark:text-neutral-300 font-semibold">{fmt(acc.monthlyCost)}</span></span>
+                                                        </div>
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
+                                    </div>
+                                )}
+                                </div>
+                            </div>
+
+                            {mtd?.lastUpdated && (
+                                <div className="text-center text-xs text-neutral-400 dark:text-neutral-600 pt-1">
+                                    Last activity {new Date(mtd.lastUpdated).toLocaleString()}
+                                </div>
+                            )}
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/components/Layout/UserMenu.tsx
+++ b/components/Layout/UserMenu.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useRef, useEffect, useContext } from 'react';
 import { signOut } from 'next-auth/react';
 import { IconLogout, IconCreditCard, IconRocket, IconShare, IconTools, IconUsers, IconShield, IconSun, IconMoon, IconX, IconCurrencyDollar, IconUser, IconSettings, IconHelp, IconLoader2 } from '@tabler/icons-react';
-import { doMtdCostOp } from '@/services/mtdCostService';
+import { getUserMtdCosts } from '@/services/mtdCostService';
+import { UserCostBreakdownModal } from './UserCostBreakdownModal';
 import ColorPaletteSelector, { COLOR_PALETTES } from './ColorPaletteSelector';
 import HomeContext from '@/pages/api/home/home.context';
 import { AssistantAdminUI } from '../Admin/AssistantAdminUI';
@@ -17,6 +18,7 @@ import SharingDialog from '../Share/SharingDialog';
 import { ThemeService } from '@/utils/whiteLabel/themeService';
 import { Theme } from '@/types/settings';
 import toast from 'react-hot-toast';
+import { getMonthlyLimit } from '@/types/rateLimit';
 
 
 interface UserMenuProps {
@@ -34,8 +36,10 @@ export const UserMenu: React.FC<UserMenuProps> = ({
   cognitoDomain,
   cognitoClientId,
 }) => {
-  const { dispatch, state: { lightMode, showUserMenu, featureFlags, supportEmail }, dispatch: homeDispatch } = useContext(HomeContext);
+  const { dispatch, state: { lightMode, showUserMenu, featureFlags, supportEmail, adminRateLimits, defaultAccount }, dispatch: homeDispatch } = useContext(HomeContext);
   const [mtdCost, setMtdCost] = useState<string>('0');
+  const [mtdCostNumeric, setMtdCostNumeric] = useState<number>(0);
+  const [showCostBreakdown, setShowCostBreakdown] = useState<boolean>(false);
   const [currentPalette, setCurrentPalette] = useState<string>('warm-browns');
   const [currentTone, setCurrentTone] = useState<'userPrimary' | 'userSecondary' | 'assistantPrimary' | 'assistantSecondary'>('userPrimary');
   const menuRef = useRef<HTMLDivElement>(null);
@@ -51,7 +55,7 @@ export const UserMenu: React.FC<UserMenuProps> = ({
       window.dispatchEvent(new Event('updateFeatureSettings'));
   }, [featureFlags]);
 
-   const showMtdCost = featureFlagsRef.current.mtdCost
+   const showMtdCost = featureFlags.mtdCost
    
    let settingRef = useRef<Settings | null>(null);
     // prevent recalling the getSettings function
@@ -91,12 +95,16 @@ export const UserMenu: React.FC<UserMenuProps> = ({
             }
         };
 
+        const handleOpenCostBreakdown = () => setShowCostBreakdown(true);
+
         window.addEventListener('openAstAdminInterfaceTrigger', handleAstAdminEvent);
         window.addEventListener('openLayeredBuilderTrigger', handleLayeredBuilderEvent);
+        window.addEventListener('openCostBreakdown', handleOpenCostBreakdown);
 
         return () => {
             window.removeEventListener('openAstAdminInterfaceTrigger', handleAstAdminEvent);
             window.removeEventListener('openLayeredBuilderTrigger', handleLayeredBuilderEvent);
+            window.removeEventListener('openCostBreakdown', handleOpenCostBreakdown);
         };
     }, []);
 
@@ -235,18 +243,20 @@ export const UserMenu: React.FC<UserMenuProps> = ({
 
       const fetchMtdCost = async () => {
         if (isFetching) return;
-
         isFetching = true;
-
         try {
-          const result = await doMtdCostOp();
-          if (result && "MTD Cost" in result && result["MTD Cost"] !== undefined) {
-            setMtdCost(`$${result["MTD Cost"].toFixed(2)}`);
+          const result = await getUserMtdCosts();
+          if (result.success) {
+            const numeric = result.data.totalCost;
+            setMtdCostNumeric(numeric);
+            setMtdCost(`$${numeric.toFixed(2)}`);
           } else {
+            setMtdCostNumeric(0);
             setMtdCost('$0.00');
           }
         } catch (error) {
           console.error("Error fetching MTD cost:", error);
+          setMtdCostNumeric(0);
           setMtdCost('$0.00');
         } finally {
           isFetching = false;
@@ -286,6 +296,26 @@ export const UserMenu: React.FC<UserMenuProps> = ({
       return processedName.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2);
     }
     return email?.charAt(0).toUpperCase() || 'U';
+  };
+
+  // Utilization helpers
+  const getEffectiveRateLimit = () => {
+    const personal = defaultAccount?.rateLimit;
+    if (personal && personal.rate !== null && personal.period !== 'Unlimited') return personal;
+    // From the admin limits list, only use the monthly limit for MTD comparison
+    return getMonthlyLimit(adminRateLimits ?? []);
+  };
+
+  const getUtilizationPercent = (): number | null => {
+    const limit = getEffectiveRateLimit();
+    if (!limit || !limit.rate || limit.rate === 0) return null;
+    return Math.min((mtdCostNumeric / limit.rate) * 100, 100);
+  };
+
+  const getMtdColors = (pct: number | null) => {
+    if (pct === null || pct < 50) return { text: 'text-blue-600 dark:text-blue-400', bar: 'bg-blue-500', ring: null, pulse: false };
+    if (pct < 80) return { text: 'text-yellow-600 dark:text-yellow-400', bar: 'bg-yellow-400', ring: 'ring-yellow-400', pulse: false };
+    return { text: 'text-red-600 dark:text-red-400', bar: 'bg-red-500', ring: 'ring-red-500', pulse: true };
   };
 
   // Get current color palette's userPrimary color
@@ -375,10 +405,25 @@ export const UserMenu: React.FC<UserMenuProps> = ({
 
   return (
     <>
+      {/* Cost Breakdown Modal */}
+      {showCostBreakdown && email && (
+        <UserCostBreakdownModal
+          email={email}
+          onClose={() => setShowCostBreakdown(false)}
+        />
+      )}
+
       {/* Persistent User Button - Always visible in top right */}
       <button
         onClick={handleToggleMenu}
-        className="fixed top-4 right-4 z-50 "
+        className={`fixed top-4 right-4 z-50 rounded-full ${
+          (() => {
+            const pct = getUtilizationPercent();
+            const colors = getMtdColors(pct);
+            if (!colors.ring) return '';
+            return `ring-2 ring-offset-2 ${colors.ring}${colors.pulse ? ' animate-pulse' : ''}`;
+          })()
+        }`}
         title="User Menu"
         id="userMenu"
       >
@@ -503,14 +548,36 @@ export const UserMenu: React.FC<UserMenuProps> = ({
             </div>
 
             {showMtdCost && (
-              <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-600/50">
+              <div
+                className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-600/50 cursor-pointer hover:bg-neutral-50 dark:hover:bg-neutral-700/40 transition-colors"
+                onClick={() => setShowCostBreakdown(true)}
+                title="Click for cost breakdown"
+              >
                 <div className="flex items-center gap-2 mb-1.5">
-                  <IconCreditCard size={16} className="enhanced-icon text-blue-500" />
+                  <IconCreditCard size={16} className={`enhanced-icon ${
+                    (() => { const pct = getUtilizationPercent(); return pct !== null && pct >= 80 ? 'text-red-500' : pct !== null && pct >= 50 ? 'text-yellow-500' : 'text-blue-500'; })()
+                  }`} />
                   <div className="sidebar-text font-medium text-neutral-700 dark:text-neutral-300">Month-To-Date Cost</div>
                 </div>
-                <div className="text-lg font-bold text-blue-600 dark:text-blue-400 text-center transition-all duration-300 hover:scale-105" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.1)' }}>
-                 {mtdCost === '0' ? <div className="flex justify-center"> <IconLoader2 size={24} className="animate-spin" /> </div> : <>{mtdCost}</>}  
-                </div>
+                {mtdCost === '0' ? (
+                  <div className="flex justify-center"><IconLoader2 size={24} className="animate-spin" /></div>
+                ) : (
+                  <>
+                    <div className={`text-lg font-bold text-center transition-all duration-300 hover:scale-105 ${
+                      getMtdColors(getUtilizationPercent()).text
+                    }`} style={{ textShadow: '0 1px 2px rgba(0,0,0,0.1)' }}>
+                      {mtdCost}
+                    </div>
+                    <div className="text-center">
+                      <span
+                        className="text-[11px] text-neutral-400 dark:text-neutral-500 hover:text-blue-500 dark:hover:text-blue-400 cursor-pointer transition-colors underline underline-offset-2"
+                        onClick={(e) => { e.stopPropagation(); setShowCostBreakdown(true); }}
+                      >
+                        View breakdown
+                      </span>
+                    </div>
+                  </>
+                )}
               </div>
             )}
 

--- a/components/Settings/AccountComponents/Account.tsx
+++ b/components/Settings/AccountComponents/Account.tsx
@@ -221,9 +221,15 @@ export const Accounts: FC<Props> = ({ accounts, setAccounts, defaultAccount, set
                         <div className="accounts-info-icon">💳</div>
                     </h3>
                     <p className="accounts-info-description">
-                        Add COA strings for billing charges back to specific accounts. 
+                        Add COA strings for billing charges back to specific accounts.
                         Certain features require at least one COA string. You can edit rate limits and must save your changes to apply them.
                     </p>
+                    <div className="mt-3 flex items-start gap-2 rounded-md border border-yellow-400 bg-yellow-50 dark:bg-yellow-900/20 dark:border-yellow-600 px-4 py-3">
+                        <span className="text-yellow-600 dark:text-yellow-400 text-lg leading-tight">⚠️</span>
+                        <p className="text-sm text-yellow-800 dark:text-yellow-300">
+                            <strong>Important:</strong> By configuring a rate limit on an account, you acknowledge that usage up to that limit may result in charges. Any spending beyond what is covered under your plan or institution remains your responsibility. Please set limits that reflect your intended usage.
+                        </p>
+                    </div>
                 </div>
             </div>
 

--- a/components/Settings/AccountComponents/RateLimit.tsx
+++ b/components/Settings/AccountComponents/RateLimit.tsx
@@ -12,10 +12,11 @@ interface RateLimitProps {
     period: PeriodType;
     setPeriod: (s:PeriodType) => void;
     rate: string;
-    setRate: (s:string) => void; 
+    setRate: (s:string) => void;
+    excludePeriods?: PeriodType[];
 }
 
-export const RateLimiter: FC<RateLimitProps> = ({period, setPeriod, rate, setRate}) => {
+export const RateLimiter: FC<RateLimitProps> = ({period, setPeriod, rate, setRate, excludePeriods = []}) => {
     
     const calcCostWidth = () => {
         return Math.max(44 + ((rate.length - 5) * 9), 44);
@@ -42,7 +43,7 @@ export const RateLimiter: FC<RateLimitProps> = ({period, setPeriod, rate, setRat
                 value={period}
                 onChange={(e) => setPeriod(e.target.value as PeriodType)}
             >
-                {periodTypes.map(p =>  <option key={p} className="ml-6" value={p}>{p}</option>)}
+                {periodTypes.filter(p => p !== 'Unlimited' && (p === period || !excludePeriods.includes(p))).map(p =>  <option key={p} className="ml-6" value={p}>{p}</option>)}
             </select>
 
             {period !== UNLIMITED && (

--- a/pages/api/home/home.state.tsx
+++ b/pages/api/home/home.state.tsx
@@ -20,6 +20,7 @@ import { ExtractedFact } from '@/types/memory';
 import { Features } from '@/types/features';
 import { PromptCostAlert } from '@/components/Admin/AdminUI';
 import { LayeredAssistant } from '@/types/layeredAssistant';
+import { RateLimit, RateLimits } from '@/types/rateLimit';
 
 export interface HomeInitialState {
   defaultAccount: Account | undefined;
@@ -97,6 +98,8 @@ export interface HomeInitialState {
   canAddWebSearchApiKey: boolean;
   webSearchUserMessage: string | null;
   userDocumentationUrl: string;
+  adminRateLimits: RateLimits;
+  groupRateLimits: { groupName: string; limits: RateLimits }[];
   promptCostAlertModal: {
     isOpen: boolean;
     message: string;
@@ -194,5 +197,7 @@ export const initialState: HomeInitialState = {
   promptCostAlertModal: null,
   canAddWebSearchApiKey: false,
   webSearchUserMessage: null,
-  userDocumentationUrl: ''
+  userDocumentationUrl: '',
+  adminRateLimits: [],
+  groupRateLimits: []
 };

--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -79,7 +79,7 @@ import { addDateAttribute, getFullTimestamp, getDateName } from '@/utils/app/dat
 import HomeContext, {  ClickContext, Processor } from './home.context';
 import { ReservedTags } from '@/types/tags';
 import { noCoaAccount } from '@/types/accounts';
-import { noRateLimit } from '@/types/rateLimit';
+import { noRateLimit, normalizeRateLimits } from '@/types/rateLimit';
 import { fetchAstAdminGroups } from '@/services/groupsService';
 import { contructGroupData } from '@/utils/app/groups';
 import { getAllArtifacts } from '@/services/artifactsService';
@@ -858,13 +858,30 @@ const Home = ({
                             dispatch({ field: 'userDocumentationUrl', value: docUrl });
                         }
                     }
+                    if (AdminConfigTypes.RATE_LIMIT in data) {
+                        dispatch({ field: 'adminRateLimits', value: normalizeRateLimits(data[AdminConfigTypes.RATE_LIMIT]) });
+                    }
+                    console.log("data", data);
+                    if ('groupRateLimits' in data) {
+                        const rawGroupLimits: Record<string, any> = data['groupRateLimits'] || {};
+                        const groupRateLimits = Object.entries(rawGroupLimits)
+                            .map(([groupName, rateLimit]) => ({
+                                groupName,
+                                limits: normalizeRateLimits(rateLimit).filter(
+                                    (l: any) => l && l.rate !== null && l.period !== 'Unlimited'
+                                ),
+                            }))
+                            .filter((g) => g.limits.length > 0);
+                        dispatch({ field: 'groupRateLimits', value: groupRateLimits });
+                    }
 
                 } else {
                     console.log("Failed to fetch user app configs.");
                 }
             } catch (e) {
                 console.log("Failed to fetch user app configs: ", e);
-            }  
+            }
+
         };
 
         const fetchSettings = async () => {

--- a/services/mtdCostService.ts
+++ b/services/mtdCostService.ts
@@ -116,7 +116,24 @@ export const getAllUserMtdCostsRecursive = async (
 
 
 
-export const getUserMtdCosts = async () => {
+export interface UserMtdCosts {
+    email: string;
+    dailyCost: number;
+    monthlyCost: number;
+    totalCost: number;
+    hourlyCost: number[]; // 24 values, index = UTC hour
+    accounts: Array<{
+        accountInfo: string;
+        dailyCost: number;
+        monthlyCost: number;
+        totalCost: number;
+        timestamp: string | null;
+    }>;
+    lastUpdated: string | null;
+    timestamp: string;
+}
+
+export const getUserMtdCosts = async (): Promise<{ success: true; data: UserMtdCosts } | { success: false; message: string }> => {
     const op = {
         method: 'POST',
         path: URL_PATH,
@@ -127,7 +144,7 @@ export const getUserMtdCosts = async () => {
 
     try {
         const result = await doRequestOp(op);
-        if (result && result.email) return { success: true, data: result };
+        if (result && result.email) return { success: true, data: result as UserMtdCosts };
 
     } catch (error) {
         console.error('Error in getUserMtdCosts:', error);

--- a/types/rateLimit.ts
+++ b/types/rateLimit.ts
@@ -3,6 +3,9 @@ export interface RateLimit {
     rate: number | null;
 }
 
+// A list of rate limits (admin/group can have multiple simultaneous limits)
+export type RateLimits = RateLimit[];
+
 export const periodTypes = ["Unlimited", "Daily", "Hourly", "Monthly", "Total"] as const;
 export type PeriodType = typeof periodTypes[number];
 
@@ -20,3 +23,34 @@ export const noRateLimit: RateLimit = {'period' : UNLIMITED, 'rate': null};
 export const rateLimitObj = (period: PeriodType, rate: string) => {
     return period === UNLIMITED ? noRateLimit : {'period' : period, 'rate': Number(rate.replace('$', ''))} as RateLimit
 }
+
+/**
+ * Normalize a single RateLimit or RateLimit[] into always RateLimit[].
+ * Handles backward compatibility with old single-object storage format.
+ */
+export const normalizeRateLimits = (limitOrList: RateLimit | RateLimit[] | null | undefined): RateLimit[] => {
+    if (!limitOrList) return [];
+    if (Array.isArray(limitOrList)) return limitOrList.filter(l => l && l.period);
+    return [limitOrList];
+};
+
+/**
+ * Find the monthly limit from a list (used for MTD utilization display).
+ * Returns the most restrictive (lowest rate) monthly limit if multiple exist.
+ */
+export const getMonthlyLimit = (limits: RateLimit[]): RateLimit | null => {
+    const monthlyLimits = limits.filter(l => l.period === 'Monthly' && l.rate !== null);
+    if (monthlyLimits.length === 0) return null;
+    return monthlyLimits.reduce((min, curr) =>
+        (curr.rate as number) < (min.rate as number) ? curr : min
+    );
+};
+
+/**
+ * Format a list of rate limits as a compact display string, e.g. "$300.00/Monthly + $30.00/Hourly"
+ */
+export const formatRateLimits = (limits: RateLimit[]): string => {
+    const active = limits.filter(l => l.rate !== null && l.period !== 'Unlimited');
+    if (active.length === 0) return 'Unlimited';
+    return active.map(l => formatRateLimit(l)).join(' | ');
+};


### PR DESCRIPTION
…breakdown

- Add paged RateLimitUtilization component (mini + full variants) with personal-first rule
- Add UserCostBreakdownModal with MTD spend, hourly chart, and account breakdown
- Surface group rate limits from getUserAppConfigs into HomeContext
- Pinned bar shows clickable "MTD Cost: $X.XX" + chart icon hover popover
- Clicking MTD Cost dispatches openCostBreakdown event to open modal from UserMenu
- Fix MTD cost reactivity in UserMenu (featureFlags state vs stale ref)
- Admin rate limit UI polish across Configurations, Account, and RateLimit components