### PR TITLE
fix alignment issues with tab sidebar buttons

### DIFF
--- a/components/TabSidebar/TabSidebar.tsx
+++ b/components/TabSidebar/TabSidebar.tsx
@@ -112,7 +112,7 @@ export const TabSidebar: React.FC<TabSidebarProps> = ({ side, children, footerCo
                 zIndex: '20 !important'
               }}>
             {isMultipleTabs && (
-                <div className="relative flex flex-row gap-1 px-3 pt-3 pb-0 bg-gradient-to-r from-neutral-100 to-neutral-50 dark:from-[#202123] dark:to-[#1c1c1e] overflow-hidden">
+                <div className="relative flex flex-row gap-1 px-3 pt-3 pb-0 flex-shrink-0 bg-gradient-to-r from-neutral-100 to-neutral-50 dark:from-[#202123] dark:to-[#1c1c1e] overflow-hidden">
                 {/* Animated gradient background */}
                 <div className="absolute inset-0 bg-gradient-to-r from-blue-50/30 via-purple-50/20 to-pink-50/30 dark:from-blue-900/5 dark:via-purple-900/5 dark:to-pink-900/5 animate-gradient-x"></div>
                     {!chatSide() && <CloseSidebarButton onClick={toggleOpen} side={side} isHovered={isHovered} /> } 


### PR DESCRIPTION
I included before and after videos showing the changes that I made. Before the blue bar was not even among the buttons, it would be too high for the assistants (sparkles) button and the same alignment for the other buttons as shown:


https://github.com/user-attachments/assets/6036a8a1-1458-4da5-9f9d-d76931bb5904


https://github.com/user-attachments/assets/86b9dcb9-52d6-4ea8-8aae-97ce01fec51e

