### PR TITLE
feat: embed open-notebook with notebook list and sources panel

### DIFF
--- a/components/Notebook/AddSourceDialog.tsx
+++ b/components/Notebook/AddSourceDialog.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import { Modal } from '@/components/ReusableComponents/Modal';
+import {
+    createSourceFromText,
+    createSourceFromUrl,
+    SourceListItem,
+} from '@/services/notebookSourcesService';
+
+type SourceType = 'url' | 'text';
+
+interface Props {
+    notebookId: string;
+    onClose: () => void;
+    onCreated: (source: SourceListItem) => void;
+}
+
+export const AddSourceDialog = ({ notebookId, onClose, onCreated }: Props) => {
+    const [tab, setTab] = useState<SourceType>('url');
+    const [url, setUrl] = useState('');
+    const [content, setContent] = useState('');
+    const [title, setTitle] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const trimmedUrl = url.trim();
+    const trimmedContent = content.trim();
+    const trimmedTitle = title.trim();
+
+    const canSubmit = !submitting && (
+        (tab === 'url' && trimmedUrl.length > 0) ||
+        (tab === 'text' && trimmedContent.length > 0)
+    );
+
+    const handleSubmit = async () => {
+        if (!canSubmit) return;
+        setSubmitting(true);
+        setError(null);
+
+        const result = tab === 'url'
+            ? await createSourceFromUrl({
+                notebookId,
+                url: trimmedUrl,
+                title: trimmedTitle || undefined,
+            })
+            : await createSourceFromText({
+                notebookId,
+                content: trimmedContent,
+                title: trimmedTitle || undefined,
+            });
+
+        setSubmitting(false);
+        if (!result) {
+            setError('Failed to add source.');
+            return;
+        }
+        onCreated(result);
+        onClose();
+    };
+
+    const tabClass = (active: boolean) =>
+        `flex-1 px-3 py-2 text-sm border-b-2 ${
+            active
+                ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                : 'border-transparent text-neutral-500 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200'
+        }`;
+
+    return (
+        <Modal
+            title="Add Source"
+            onCancel={onClose}
+            onSubmit={handleSubmit}
+            submitLabel={submitting ? 'Adding…' : 'Add'}
+            disableSubmit={!canSubmit}
+            width={() => 520}
+            height={() => 460}
+            content={
+                <div className="flex flex-col gap-3 p-2 text-neutral-800 dark:text-neutral-100">
+                    <div className="flex border-b border-neutral-200 dark:border-neutral-700">
+                        <button type="button" className={tabClass(tab === 'url')} onClick={() => setTab('url')}>
+                            URL
+                        </button>
+                        <button type="button" className={tabClass(tab === 'text')} onClick={() => setTab('text')}>
+                            Text
+                        </button>
+                    </div>
+
+                    {tab === 'url' && (
+                        <div className="flex flex-col gap-1">
+                            <label htmlFor="source-url" className="text-sm font-medium">
+                                URL <span className="text-red-500">*</span>
+                            </label>
+                            <input
+                                id="source-url"
+                                type="url"
+                                autoFocus
+                                value={url}
+                                onChange={(e) => setUrl(e.target.value)}
+                                placeholder="https://example.com/article"
+                                className="rounded border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-600 dark:bg-[#40414f] dark:text-neutral-100"
+                            />
+                        </div>
+                    )}
+
+                    {tab === 'text' && (
+                        <div className="flex flex-col gap-1">
+                            <label htmlFor="source-text" className="text-sm font-medium">
+                                Content <span className="text-red-500">*</span>
+                            </label>
+                            <textarea
+                                id="source-text"
+                                autoFocus
+                                value={content}
+                                onChange={(e) => setContent(e.target.value)}
+                                placeholder="Paste the text you want to ingest…"
+                                rows={8}
+                                className="resize-none rounded border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-600 dark:bg-[#40414f] dark:text-neutral-100"
+                            />
+                        </div>
+                    )}
+
+                    <div className="flex flex-col gap-1">
+                        <label htmlFor="source-title" className="text-sm font-medium">
+                            Title (optional)
+                        </label>
+                        <input
+                            id="source-title"
+                            type="text"
+                            value={title}
+                            onChange={(e) => setTitle(e.target.value)}
+                            placeholder="Auto-detected if blank"
+                            className="rounded border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-600 dark:bg-[#40414f] dark:text-neutral-100"
+                        />
+                    </div>
+
+                    {error && (
+                        <div className="text-sm text-red-600 dark:text-red-400">{error}</div>
+                    )}
+                </div>
+            }
+        />
+    );
+};
+
+export default AddSourceDialog;

--- a/components/Notebook/CreateNotebookDialog.tsx
+++ b/components/Notebook/CreateNotebookDialog.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { Modal } from '@/components/ReusableComponents/Modal';
+import { createNotebook, NotebookSummary } from '@/services/notebookService';
+
+interface Props {
+    onClose: () => void;
+    onCreated: (notebook: NotebookSummary) => void;
+}
+
+export const CreateNotebookDialog = ({ onClose, onCreated }: Props) => {
+    const [name, setName] = useState('');
+    const [description, setDescription] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const trimmedName = name.trim();
+    const canSubmit = trimmedName.length > 0 && !submitting;
+
+    const handleSubmit = async () => {
+        if (!canSubmit) return;
+        setSubmitting(true);
+        setError(null);
+        const result = await createNotebook({
+            name: trimmedName,
+            description: description.trim() || undefined,
+        });
+        setSubmitting(false);
+        if (!result) {
+            setError('Failed to create notebook.');
+            return;
+        }
+        onCreated(result);
+        onClose();
+    };
+
+    return (
+        <Modal
+            title="New Notebook"
+            onCancel={onClose}
+            onSubmit={handleSubmit}
+            submitLabel={submitting ? 'Creating…' : 'Create'}
+            disableSubmit={!canSubmit}
+            width={() => 480}
+            height={() => 360}
+            content={
+                <div className="flex flex-col gap-4 p-2 text-neutral-800 dark:text-neutral-100">
+                    <div className="flex flex-col gap-1">
+                        <label htmlFor="notebook-name" className="text-sm font-medium">
+                            Name <span className="text-red-500">*</span>
+                        </label>
+                        <input
+                            id="notebook-name"
+                            type="text"
+                            autoFocus
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            placeholder="My research notebook"
+                            className="rounded border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-600 dark:bg-[#40414f] dark:text-neutral-100"
+                        />
+                    </div>
+
+                    <div className="flex flex-col gap-1">
+                        <label htmlFor="notebook-description" className="text-sm font-medium">
+                            Description
+                        </label>
+                        <textarea
+                            id="notebook-description"
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            placeholder="What's this notebook about?"
+                            rows={4}
+                            className="resize-none rounded border border-neutral-300 bg-white px-3 py-2 text-sm dark:border-neutral-600 dark:bg-[#40414f] dark:text-neutral-100"
+                        />
+                    </div>
+
+                    {error && (
+                        <div className="text-sm text-red-600 dark:text-red-400">{error}</div>
+                    )}
+                </div>
+            }
+        />
+    );
+};
+
+export default CreateNotebookDialog;

--- a/components/Notebook/NotebookApp.tsx
+++ b/components/Notebook/NotebookApp.tsx
@@ -1,0 +1,281 @@
+import { useContext, useEffect, useState } from 'react';
+import {
+    IconArrowLeft,
+    IconNotebook,
+    IconPlus,
+    IconTrash,
+} from '@tabler/icons-react';
+import HomeContext from '@/pages/api/home/home.context';
+import {
+    deleteNotebook,
+    listNotebooks,
+    NotebookSummary,
+} from '@/services/notebookService';
+import { ConfirmModal } from '@/components/ReusableComponents/ConfirmModal';
+import { CreateNotebookDialog } from './CreateNotebookDialog';
+import { NotebookDetail } from './NotebookDetail';
+
+const AVATAR_GRADIENTS = [
+    'from-purple-500 to-indigo-500',
+    'from-fuchsia-500 to-purple-500',
+    'from-blue-500 to-purple-500',
+    'from-pink-500 to-purple-500',
+    'from-violet-500 to-fuchsia-500',
+    'from-indigo-500 to-blue-500',
+];
+
+const gradientFor = (id: string) => {
+    let hash = 0;
+    for (let i = 0; i < id.length; i++) hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
+    return AVATAR_GRADIENTS[hash % AVATAR_GRADIENTS.length];
+};
+
+const initialsOf = (name?: string) => {
+    if (!name) return '?';
+    const parts = name.trim().split(/\s+/);
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+};
+
+const formatRelative = (iso?: string) => {
+    if (!iso) return '';
+    const d = new Date(iso.replace(' ', 'T'));
+    if (isNaN(d.getTime())) return '';
+    const diffMs = Date.now() - d.getTime();
+    const mins = Math.round(diffMs / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.round(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.round(hours / 24);
+    if (days < 30) return `${days}d ago`;
+    return d.toLocaleDateString();
+};
+
+export const NotebookApp = () => {
+    const { dispatch } = useContext(HomeContext);
+
+    const [notebooks, setNotebooks] = useState<NotebookSummary[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+    const [selected, setSelected] = useState<NotebookSummary | null>(null);
+    const [showCreate, setShowCreate] = useState<boolean>(false);
+    const [pendingDelete, setPendingDelete] = useState<NotebookSummary | null>(null);
+    const [deleting, setDeleting] = useState<boolean>(false);
+
+    const goBackToChat = () => dispatch({ field: 'page', value: 'chat' });
+    const goBackToList = () => setSelected(null);
+
+    const fetchNotebooks = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const data = await listNotebooks({ order_by: 'updated desc' });
+            setNotebooks(data);
+        } catch (e: any) {
+            setError(e?.message || 'Failed to load notebooks');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchNotebooks();
+    }, []);
+
+    const handleCreated = (created: NotebookSummary) => {
+        setNotebooks((prev) => [created, ...prev]);
+        setSelected(created);
+    };
+
+    const confirmDelete = async () => {
+        if (!pendingDelete) return;
+        setDeleting(true);
+        const ok = await deleteNotebook(pendingDelete.id);
+        setDeleting(false);
+        if (!ok) {
+            setError(`Couldn't delete "${pendingDelete.name}".`);
+            setPendingDelete(null);
+            return;
+        }
+        setNotebooks((prev) => prev.filter((nb) => nb.id !== pendingDelete.id));
+        if (selected?.id === pendingDelete.id) setSelected(null);
+        setPendingDelete(null);
+    };
+
+    return (
+        <div className="flex flex-col flex-1 h-full bg-white dark:bg-[#343541] text-neutral-800 dark:text-neutral-100">
+            <div className="flex items-center gap-3 border-b border-gray-200 dark:border-neutral-700 bg-gradient-to-b from-gray-50 to-white dark:from-gray-800 dark:to-[#343541] pl-4 pr-20 py-3">
+                <button
+                    onClick={selected ? goBackToList : goBackToChat}
+                    title={selected ? 'Back to notebooks' : 'Back to chat'}
+                    className="flex h-8 w-8 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white transition-colors"
+                >
+                    <IconArrowLeft size={20} />
+                </button>
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br from-purple-500 to-indigo-600 text-white shadow-sm">
+                    <IconNotebook size={18} />
+                </div>
+                <div className="flex flex-col min-w-0">
+                    <h1 className="text-base font-semibold leading-tight truncate">
+                        {selected ? selected.name || '(untitled)' : 'Notebooks'}
+                    </h1>
+                    {!selected && (
+                        <span className="text-xs text-gray-500 dark:text-gray-400">
+                            {notebooks.length} {notebooks.length === 1 ? 'notebook' : 'notebooks'}
+                        </span>
+                    )}
+                    {selected?.description && (
+                        <span className="text-xs text-gray-500 dark:text-gray-400 line-clamp-1 max-w-xl">
+                            {selected.description}
+                        </span>
+                    )}
+                </div>
+
+            </div>
+
+            <div className="flex-1 overflow-auto px-6 py-6 bg-neutral-50 dark:bg-[#343541]">
+                {selected ? (
+                    <NotebookDetail notebookId={selected.id} initialData={selected} />
+                ) : (
+                    <>
+                        {loading && (
+                            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                                {[0, 1, 2].map((i) => (
+                                    <div
+                                        key={i}
+                                        className="h-36 animate-pulse rounded-xl border border-gray-200 bg-white dark:border-neutral-700 dark:bg-[#2b2c36]"
+                                    />
+                                ))}
+                            </div>
+                        )}
+
+                        {!loading && error && (
+                            <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-900/50 dark:bg-red-900/20 dark:text-red-300">
+                                <div className="font-medium">Couldn&apos;t load notebooks</div>
+                                <div className="mt-1 text-sm opacity-80">{error}</div>
+                            </div>
+                        )}
+
+                        {!loading && !error && notebooks.length === 0 && (
+                            <div className="flex flex-col items-center justify-center py-20 text-center">
+                                <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-purple-500 to-indigo-600 text-white shadow-lg">
+                                    <IconNotebook size={28} />
+                                </div>
+                                <h2 className="text-lg font-semibold">No notebooks yet</h2>
+                                <p className="mt-1 max-w-sm text-sm text-gray-500 dark:text-gray-400">
+                                    Create your first notebook to start collecting sources, taking notes,
+                                    and chatting with your research.
+                                </p>
+                                <button
+                                    onClick={() => setShowCreate(true)}
+                                    className="mt-5 flex items-center gap-1.5 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-purple-700 transition-all duration-200"
+                                >
+                                    <IconPlus size={16} />
+                                    Create notebook
+                                </button>
+                            </div>
+                        )}
+
+                        {!loading && !error && notebooks.length > 0 && (
+                            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                                {notebooks.map((nb) => (
+                                    <div
+                                        key={nb.id}
+                                        className="group relative cursor-pointer rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-purple-300 hover:shadow-md dark:border-neutral-700 dark:bg-[#2b2c36] dark:hover:border-purple-500/60"
+                                        onClick={() => setSelected(nb)}
+                                    >
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                setPendingDelete(nb);
+                                            }}
+                                            title="Delete notebook"
+                                            className="absolute top-2 right-2 invisible rounded-full p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600 group-hover:visible dark:hover:bg-red-900/30"
+                                        >
+                                            <IconTrash size={16} />
+                                        </button>
+
+                                        <div className="flex items-start gap-3">
+                                            <div
+                                                className={`flex h-10 w-10 flex-none items-center justify-center rounded-lg bg-gradient-to-br ${gradientFor(
+                                                    nb.id,
+                                                )} text-sm font-semibold text-white shadow-sm`}
+                                            >
+                                                {initialsOf(nb.name)}
+                                            </div>
+                                            <div className="min-w-0 flex-1">
+                                                <div className="truncate font-semibold leading-snug">
+                                                    {nb.name || '(untitled)'}
+                                                </div>
+                                                {nb.description ? (
+                                                    <div className="mt-0.5 line-clamp-2 text-xs text-gray-500 dark:text-gray-400">
+                                                        {nb.description}
+                                                    </div>
+                                                ) : (
+                                                    <div className="mt-0.5 text-xs italic text-gray-400 dark:text-gray-500">
+                                                        No description
+                                                    </div>
+                                                )}
+                                            </div>
+                                        </div>
+
+                                        <div className="mt-4 flex flex-wrap items-center gap-1.5">
+                                            <span className="rounded-full bg-purple-50 px-2 py-0.5 text-[11px] font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-300">
+                                                {nb.source_count ?? 0} sources
+                                            </span>
+                                            <span className="rounded-full bg-indigo-50 px-2 py-0.5 text-[11px] font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300">
+                                                {nb.note_count ?? 0} notes
+                                            </span>
+                                            {nb.updated && (
+                                                <span className="ml-auto text-[11px] text-gray-400 dark:text-gray-500">
+                                                    {formatRelative(nb.updated)}
+                                                </span>
+                                            )}
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </>
+                )}
+            </div>
+
+            {!selected && !loading && (
+                <button
+                    onClick={() => setShowCreate(true)}
+                    title="New notebook"
+                    className="fixed bottom-6 right-6 z-30 flex items-center gap-2 rounded-full bg-gradient-to-br from-purple-600 to-indigo-600 px-5 py-3 text-sm font-medium text-white shadow-lg hover:shadow-xl hover:from-purple-700 hover:to-indigo-700 transition-all duration-200"
+                >
+                    <IconPlus size={18} />
+                    New notebook
+                </button>
+            )}
+
+            {showCreate && (
+                <CreateNotebookDialog
+                    onClose={() => setShowCreate(false)}
+                    onCreated={handleCreated}
+                />
+            )}
+
+            {pendingDelete && (
+                <ConfirmModal
+                    title="Delete notebook?"
+                    message={
+                        <span>
+                            Delete <b>{pendingDelete.name || '(untitled)'}</b>? This will also remove
+                            its sources, notes, and chat sessions. This can&apos;t be undone.
+                        </span>
+                    }
+                    confirmLabel={deleting ? 'Deleting…' : 'Delete'}
+                    denyLabel="Cancel"
+                    onConfirm={confirmDelete}
+                    onDeny={() => setPendingDelete(null)}
+                />
+            )}
+        </div>
+    );
+};
+
+export default NotebookApp;

--- a/components/Notebook/NotebookDetail.tsx
+++ b/components/Notebook/NotebookDetail.tsx
@@ -1,0 +1,303 @@
+import { useEffect, useState } from 'react';
+import {
+    IconFileText,
+    IconMessageCircle,
+    IconNote,
+    IconPlus,
+    IconRefresh,
+    IconTrash,
+} from '@tabler/icons-react';
+import { getNotebook, NotebookSummary } from '@/services/notebookService';
+import {
+    deleteSource,
+    listSources,
+    SourceListItem,
+} from '@/services/notebookSourcesService';
+import { ConfirmModal } from '@/components/ReusableComponents/ConfirmModal';
+import { AddSourceDialog } from './AddSourceDialog';
+
+interface Props {
+    notebookId: string;
+    initialData?: NotebookSummary;
+}
+
+export const NotebookDetail = ({ notebookId, initialData }: Props) => {
+    const [notebook, setNotebook] = useState<NotebookSummary | null>(initialData ?? null);
+    const [loading, setLoading] = useState<boolean>(!initialData);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        const load = async () => {
+            setLoading(true);
+            setError(null);
+            const result = await getNotebook(notebookId);
+            if (cancelled) return;
+            if (!result) {
+                setError('Notebook not found.');
+            } else {
+                setNotebook(result);
+            }
+            setLoading(false);
+        };
+        if (!initialData) {
+            load();
+        }
+        return () => {
+            cancelled = true;
+        };
+    }, [notebookId, initialData]);
+
+    if (loading) {
+        return <div className="text-gray-500 dark:text-gray-400">Loading notebook…</div>;
+    }
+
+    if (error || !notebook) {
+        return <div className="text-red-600 dark:text-red-400">{error ?? 'Notebook not found.'}</div>;
+    }
+
+    return (
+        <div className="flex flex-col gap-5">
+            <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-neutral-700 dark:bg-[#2b2c36]">
+                <h2 className="text-xl font-semibold">{notebook.name || '(untitled)'}</h2>
+                {notebook.description && (
+                    <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                        {notebook.description}
+                    </p>
+                )}
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <span className="rounded-full bg-purple-50 px-2.5 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-300">
+                        {notebook.source_count ?? 0} sources
+                    </span>
+                    <span className="rounded-full bg-indigo-50 px-2.5 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300">
+                        {notebook.note_count ?? 0} notes
+                    </span>
+                </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+                <SourcesPanel notebookId={notebookId} />
+                <PlaceholderPanel
+                    icon={<IconNote size={16} />}
+                    accentClass="from-emerald-500 to-teal-500"
+                    title="Notes"
+                    body="Notes porting coming next."
+                />
+                <PlaceholderPanel
+                    icon={<IconMessageCircle size={16} />}
+                    accentClass="from-pink-500 to-rose-500"
+                    title="Chat"
+                    body="Chat porting coming next."
+                />
+            </div>
+        </div>
+    );
+};
+
+const PanelShell = ({
+    icon,
+    accentClass,
+    title,
+    actions,
+    children,
+}: {
+    icon: React.ReactNode;
+    accentClass: string;
+    title: string;
+    actions?: React.ReactNode;
+    children: React.ReactNode;
+}) => (
+    <div className="rounded-xl border border-gray-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-[#2b2c36]">
+        <div className="flex items-center gap-2 border-b border-gray-200 px-4 py-3 dark:border-neutral-700">
+            <div className={`flex h-7 w-7 items-center justify-center rounded-md bg-gradient-to-br ${accentClass} text-white shadow-sm`}>
+                {icon}
+            </div>
+            <div className="text-sm font-semibold">{title}</div>
+            {actions && <div className="ml-auto flex items-center gap-1">{actions}</div>}
+        </div>
+        <div className="p-4">{children}</div>
+    </div>
+);
+
+const PlaceholderPanel = ({
+    icon,
+    accentClass,
+    title,
+    body,
+}: {
+    icon: React.ReactNode;
+    accentClass: string;
+    title: string;
+    body: string;
+}) => (
+    <PanelShell icon={icon} accentClass={accentClass} title={title}>
+        <div className="text-xs text-gray-500 dark:text-gray-400">{body}</div>
+    </PanelShell>
+);
+
+const SourcesPanel = ({ notebookId }: { notebookId: string }) => {
+    const [sources, setSources] = useState<SourceListItem[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+    const [showAdd, setShowAdd] = useState<boolean>(false);
+    const [pendingDelete, setPendingDelete] = useState<SourceListItem | null>(null);
+    const [deleting, setDeleting] = useState<boolean>(false);
+
+    const fetchSources = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const data = await listSources({ notebookId });
+            setSources(data);
+        } catch (e: any) {
+            setError(e?.message || 'Failed to load sources');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchSources();
+    }, [notebookId]);
+
+    useEffect(() => {
+        const stillProcessing = sources.some(
+            (s) => !s.embedded && s.status !== 'failed' && s.status !== 'error'
+        );
+        if (!stillProcessing) return;
+
+        const id = setInterval(() => {
+            fetchSources();
+        }, 4000);
+        return () => clearInterval(id);
+    }, [sources]);
+
+    const handleCreated = (created: SourceListItem) => {
+        setSources((prev) => [created, ...prev]);
+    };
+
+    const confirmDelete = async () => {
+        if (!pendingDelete) return;
+        setDeleting(true);
+        const ok = await deleteSource(pendingDelete.id);
+        setDeleting(false);
+        if (!ok) {
+            setError(`Couldn't delete "${pendingDelete.title || '(untitled)'}".`);
+            setPendingDelete(null);
+            return;
+        }
+        setSources((prev) => prev.filter((s) => s.id !== pendingDelete.id));
+        setPendingDelete(null);
+    };
+
+    const actions = (
+        <>
+            <button
+                onClick={fetchSources}
+                title="Refresh"
+                className="flex h-7 w-7 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white transition-colors"
+            >
+                <IconRefresh size={14} />
+            </button>
+            <button
+                onClick={() => setShowAdd(true)}
+                title="Add source"
+                className="flex items-center gap-1 rounded-md bg-purple-600 px-2 py-1 text-xs font-medium text-white shadow-sm hover:bg-purple-700 transition-colors"
+            >
+                <IconPlus size={12} />
+                Add
+            </button>
+        </>
+    );
+
+    return (
+        <PanelShell
+            icon={<IconFileText size={16} />}
+            accentClass="from-purple-500 to-indigo-500"
+            title="Sources"
+            actions={actions}
+        >
+            {loading && (
+                <div className="text-xs text-gray-500 dark:text-gray-400">Loading sources…</div>
+            )}
+
+            {!loading && error && (
+                <div className="text-xs text-red-600 dark:text-red-400">{error}</div>
+            )}
+
+            {!loading && !error && sources.length === 0 && (
+                <div className="text-xs text-gray-500 dark:text-gray-400">
+                    No sources yet. Click <span className="font-medium">Add</span> to ingest a URL or text.
+                </div>
+            )}
+
+            {!loading && !error && sources.length > 0 && (
+                <ul className="-mx-1 divide-y divide-gray-100 dark:divide-neutral-700/60">
+                    {sources.map((s) => (
+                        <li key={s.id} className="group flex items-start gap-2 px-1 py-2">
+                            <div className="flex-1 min-w-0">
+                                <div className="truncate text-sm font-medium" title={s.title || ''}>
+                                    {s.title || '(untitled)'}
+                                </div>
+                                <div className="mt-0.5 flex flex-wrap items-center gap-2 text-[11px] text-gray-500 dark:text-gray-400">
+                                    <StatusBadge source={s} />
+                                    <span>{s.embedded_chunks} chunks</span>
+                                    {s.insights_count > 0 && <span>{s.insights_count} insights</span>}
+                                </div>
+                            </div>
+                            <button
+                                onClick={() => setPendingDelete(s)}
+                                title="Delete source"
+                                className="invisible rounded-md p-1 text-gray-400 hover:bg-red-50 hover:text-red-600 group-hover:visible dark:hover:bg-red-900/30"
+                            >
+                                <IconTrash size={14} />
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+
+            {showAdd && (
+                <AddSourceDialog
+                    notebookId={notebookId}
+                    onClose={() => setShowAdd(false)}
+                    onCreated={handleCreated}
+                />
+            )}
+
+            {pendingDelete && (
+                <ConfirmModal
+                    title="Delete source?"
+                    message={
+                        <span>
+                            Delete <b>{pendingDelete.title || '(untitled)'}</b>? This removes it from
+                            the notebook and deletes its embeddings. This can&apos;t be undone.
+                        </span>
+                    }
+                    confirmLabel={deleting ? 'Deleting…' : 'Delete'}
+                    denyLabel="Cancel"
+                    onConfirm={confirmDelete}
+                    onDeny={() => setPendingDelete(null)}
+                />
+            )}
+        </PanelShell>
+    );
+};
+
+const StatusBadge = ({ source }: { source: SourceListItem }) => {
+    if (source.embedded) {
+        return (
+            <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300">
+                embedded
+            </span>
+        );
+    }
+    const status = source.status || 'processing';
+    const cls =
+        status === 'failed' || status === 'error'
+            ? 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300'
+            : 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300';
+    return <span className={`rounded-full px-2 py-0.5 ${cls}`}>{status}</span>;
+};
+
+export default NotebookDetail;

--- a/components/TabSidebar/TabSidebar.tsx
+++ b/components/TabSidebar/TabSidebar.tsx
@@ -7,6 +7,7 @@ interface TabProps {
     icon: ReactNode;
     children: ReactNode;
     title?: string;
+    onClick?: () => void;
 }
 
 export const Tab: React.FC<TabProps> = ({ icon, children }) => (
@@ -120,7 +121,10 @@ export const TabSidebar: React.FC<TabSidebarProps> = ({ side, children, footerCo
                         <button
                             key={index}
                             id="tabSelection"
-                            onClick={() => setActiveTab(index)}
+                            onClick={() => {
+                                setActiveTab(index);
+                                child.props.onClick?.();
+                            }}
                             title={child.props.title}
                             className={`group relative px-5 pb-2.5 pt-2 rounded-t transition-all duration-300 overflow-hidden ${
                                 activeTab === index 

--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -53,6 +53,7 @@ import {
     IconLogout,
     IconSparkles,
     IconHammer,
+    IconNotebook,
 } from "@tabler/icons-react";
 
 import { initialState } from './home.state';
@@ -68,6 +69,7 @@ import Loader from "@/components/Loader/Loader";
 import { ConversationAction, useHomeReducer } from "@/hooks/useHomeReducer";
 import { MyHome } from "@/components/My/MyHome";
 import { AssistantGallery } from "@/components/AssistantGallery/AssistantGallery";
+import { NotebookApp } from "@/components/Notebook/NotebookApp";
 import { DEFAULT_ASSISTANT } from '@/types/assistant';
 import { deleteAssistant, listAssistants, listLayeredAssistants } from '@/services/assistantService';
 import { LayeredAssistant } from '@/types/layeredAssistant';
@@ -1575,13 +1577,16 @@ const Home = ({
                             />
 
 
-                            <TabSidebar
-                                side={"left"}
-                            >
-                                <Tab icon={<IconMessage />} title="Chats"><Chatbar /></Tab>
-                                <Tab icon={<IconSparkles />} title="Assistants"><Promptbar /></Tab>
-                                <Tab icon={<IconHammer />} title="Settings"><SettingsBar /></Tab>
-                            </TabSidebar>
+                            {page !== 'notebook' && (
+                                <TabSidebar
+                                    side={"left"}
+                                >
+                                    <Tab icon={<IconMessage />} title="Chats" onClick={() => dispatch({ field: 'page', value: 'chat' })}><Chatbar /></Tab>
+                                    <Tab icon={<IconSparkles />} title="Assistants" onClick={() => dispatch({ field: 'page', value: 'chat' })}><Promptbar /></Tab>
+                                    <Tab icon={<IconHammer />} title="Settings" onClick={() => dispatch({ field: 'page', value: 'chat' })}><SettingsBar /></Tab>
+                                    <Tab icon={<IconNotebook />} title="Notebook" onClick={() => dispatch({ field: 'page', value: 'notebook' })}><div /></Tab>
+                                </TabSidebar>
+                            )}
 
                             <div className="flex flex-1">
                                 {page === 'chat' && (
@@ -1597,6 +1602,9 @@ const Home = ({
                                 )}
                                 {page === 'assistantGallery' && (
                                     <AssistantGallery />
+                                )}
+                                {page === 'notebook' && (
+                                    <NotebookApp />
                                 )}
                             </div>
                             

--- a/pages/api/requestOp.ts
+++ b/pages/api/requestOp.ts
@@ -43,18 +43,31 @@ const requestOp =
         // @ts-ignore
         const { accessToken } = session;
 
+        const isNotebookService = reqData.service === 'notebook';
+        // For open-notebook, X-Auth-Request-User must be the VUNet ID — sanitize_username()
+        // maps it to a per-user SurrealDB database (`user_{vunetid}`). Email/name don't match.
+        const notebookUserId =
+            (session.user as any)?.username ||
+            (session.user as any)?.email ||
+            (session.user as any)?.name;
+
         let reqPayload: reqPayload = {
             method: method,
-            headers: {
-                "Content-Type": "application/json",
-                "Authorization": `Bearer ${accessToken}` 
-            },
+            headers: isNotebookService
+                ? {
+                    "Content-Type": "application/json",
+                    "X-Auth-Request-User": notebookUserId || "",
+                }
+                : {
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${accessToken}`,
+                },
         }
 
         if (payload) {
             // Use originalPath if available (set when running locally), otherwise use path
             const pathToCheck = reqData.originalPath || reqData.path;
-            const shouldCompress = !NO_COMPRESSION_PATHS.includes(pathToCheck);
+            const shouldCompress = !isNotebookService && !NO_COMPRESSION_PATHS.includes(pathToCheck);
             
             if (shouldCompress) {
                 try {
@@ -74,13 +87,18 @@ const requestOp =
                 console.log(`Skipping compression for path: ${reqData.path}`);
             }
 
-            // Include pollRequestId if present (for polling support)
-            const bodyData: any = { data: payload };
-            if (pollRequestId) {
-                bodyData.pollRequestId = pollRequestId;
-                console.log(`Including pollRequestId in backend request: ${pollRequestId}`);
+            if (isNotebookService) {
+                // open-notebook FastAPI expects the raw JSON body, not amplify's {data: ...} wrapper
+                reqPayload.body = JSON.stringify(payload);
+            } else {
+                // Include pollRequestId if present (for polling support)
+                const bodyData: any = { data: payload };
+                if (pollRequestId) {
+                    bodyData.pollRequestId = pollRequestId;
+                    console.log(`Including pollRequestId in backend request: ${pollRequestId}`);
+                }
+                reqPayload.body = JSON.stringify(bodyData);
             }
-            reqPayload.body = JSON.stringify(bodyData);
 
         }
 
@@ -103,8 +121,15 @@ const requestOp =
 export default requestOp;
 
 
-const constructUrl = (data: any) => {  
-    let apiUrl = data.url ?? (process.env.API_BASE_URL || "");
+const constructUrl = (data: any) => {
+    let apiUrl = data.url;
+    if (!apiUrl) {
+        if (data.service === 'notebook') {
+            apiUrl = process.env.NOTEBOOK_API_URL || "";
+        } else {
+            apiUrl = process.env.API_BASE_URL || "";
+        }
+    }
 
     const path: string = data.path || "";
     const op: string = data.op || "";

--- a/services/notebookService.ts
+++ b/services/notebookService.ts
@@ -1,0 +1,74 @@
+import { doRequestOp } from "./doRequestOp";
+
+const URL_PATH = "/api/notebooks";
+const SERVICE_NAME = "notebook";
+
+export interface NotebookSummary {
+    id: string;
+    name: string;
+    description?: string;
+    archived?: boolean;
+    created?: string;
+    updated?: string;
+    source_count?: number;
+    note_count?: number;
+}
+
+export interface CreateNotebookRequest {
+    name: string;
+    description?: string;
+}
+
+export const listNotebooks = async (
+    params?: { archived?: boolean; order_by?: string }
+): Promise<NotebookSummary[]> => {
+    const op = {
+        method: 'GET',
+        path: URL_PATH,
+        op: '',
+        service: SERVICE_NAME,
+        queryParams: params as { [key: string]: string } | undefined,
+    };
+    const result = await doRequestOp(op);
+    return Array.isArray(result) ? result : [];
+};
+
+export const getNotebook = async (id: string): Promise<NotebookSummary | null> => {
+    const op = {
+        method: 'GET',
+        path: URL_PATH,
+        op: `/${encodeURIComponent(id)}`,
+        service: SERVICE_NAME,
+    };
+    const result = await doRequestOp(op);
+    if (!result || (result as any).success === false) return null;
+    return result as NotebookSummary;
+};
+
+export const createNotebook = async (
+    data: CreateNotebookRequest
+): Promise<NotebookSummary | null> => {
+    const op = {
+        method: 'POST',
+        path: URL_PATH,
+        op: '',
+        service: SERVICE_NAME,
+        data,
+    };
+    const result = await doRequestOp(op);
+    if (!result || (result as any).success === false) return null;
+    return result as NotebookSummary;
+};
+
+export const deleteNotebook = async (id: string): Promise<boolean> => {
+    const op = {
+        method: 'DELETE',
+        path: URL_PATH,
+        op: `/${encodeURIComponent(id)}`,
+        service: SERVICE_NAME,
+    };
+    const result = await doRequestOp(op);
+    if (!result) return false;
+    if ((result as any).success === false) return false;
+    return true;
+};

--- a/services/notebookSourcesService.ts
+++ b/services/notebookSourcesService.ts
@@ -1,0 +1,113 @@
+import { doRequestOp } from "./doRequestOp";
+
+const URL_PATH = "/api/sources";
+const SERVICE_NAME = "notebook";
+
+export interface SourceListItem {
+    id: string;
+    title?: string | null;
+    topics?: string[] | null;
+    asset?: { url?: string | null; file_path?: string | null; source_type?: string | null } | null;
+    embedded: boolean;
+    embedded_chunks: number;
+    insights_count: number;
+    created: string;
+    updated: string;
+    file_available?: boolean | null;
+    command_id?: string | null;
+    status?: string | null;
+    processing_info?: Record<string, unknown> | null;
+}
+
+export interface CreateSourceLinkRequest {
+    notebookId: string;
+    url: string;
+    title?: string;
+}
+
+export interface CreateSourceTextRequest {
+    notebookId: string;
+    content: string;
+    title?: string;
+}
+
+interface ListParams {
+    notebookId: string;
+    limit?: number;
+    offset?: number;
+}
+
+export const listSources = async (
+    { notebookId, limit, offset }: ListParams
+): Promise<SourceListItem[]> => {
+    const queryParams: { [key: string]: string } = { notebook_id: notebookId };
+    if (typeof limit === 'number') queryParams.limit = String(limit);
+    if (typeof offset === 'number') queryParams.offset = String(offset);
+
+    const op = {
+        method: 'GET',
+        path: URL_PATH,
+        op: '',
+        service: SERVICE_NAME,
+        queryParams,
+    };
+    const result = await doRequestOp(op);
+    return Array.isArray(result) ? result : [];
+};
+
+export const createSourceFromUrl = async (
+    { notebookId, url, title }: CreateSourceLinkRequest
+): Promise<SourceListItem | null> => {
+    const op = {
+        method: 'POST',
+        path: URL_PATH,
+        op: '/json',
+        service: SERVICE_NAME,
+        data: {
+            type: 'link',
+            url,
+            title,
+            notebooks: [notebookId],
+            embed: true,
+            async_processing: true,
+        },
+    };
+    const result = await doRequestOp(op);
+    if (!result || (result as any).success === false) return null;
+    return result as SourceListItem;
+};
+
+export const createSourceFromText = async (
+    { notebookId, content, title }: CreateSourceTextRequest
+): Promise<SourceListItem | null> => {
+    const op = {
+        method: 'POST',
+        path: URL_PATH,
+        op: '/json',
+        service: SERVICE_NAME,
+        data: {
+            type: 'text',
+            content,
+            title,
+            notebooks: [notebookId],
+            embed: true,
+            async_processing: true,
+        },
+    };
+    const result = await doRequestOp(op);
+    if (!result || (result as any).success === false) return null;
+    return result as SourceListItem;
+};
+
+export const deleteSource = async (sourceId: string): Promise<boolean> => {
+    const op = {
+        method: 'DELETE',
+        path: URL_PATH,
+        op: `/${encodeURIComponent(sourceId)}`,
+        service: SERVICE_NAME,
+    };
+    const result = await doRequestOp(op);
+    if (!result) return false;
+    if ((result as any).success === false) return false;
+    return true;
+};


### PR DESCRIPTION
Added notebook button on home page, and tried to match amplify styling with the buttons and icons inside the page that the notebook button opens up. 

Very early implementation of open-notebook with a notebook list and sources panel 

<img width="1512" height="760" alt="Screenshot 2026-05-08 at 12 38 21 PM" src="https://github.com/user-attachments/assets/1652dc30-bbfe-42d2-836c-264addf7b889" />
<img width="1512" height="760" alt="Screenshot 2026-05-08 at 12 38 29 PM" src="https://github.com/user-attachments/assets/8276d2a6-dc48-4064-ac20-fe2535695996" />
<img width="1512" height="760" alt="Screenshot 2026-05-08 at 12 38 53 PM" src="https://github.com/user-attachments/assets/ff0d77b4-d77c-422a-8907-36afa9dd6c1b" />


