### PR TITLE
feat(workflows): streamline workflow builder UX and add step-level co…

### DIFF
--- a/components/AssistantWorkflows/AssistantWorkflowBuilder.tsx
+++ b/components/AssistantWorkflows/AssistantWorkflowBuilder.tsx
@@ -93,8 +93,6 @@ export const AssistantWorkflowBuilder: React.FC<WorkflowTemplateBuilderProps> = 
   const [showWorkflowBuilder, setShowWorkflowBuilder] = useState(false);
   const [workflowBuilderWorkflow, setWorkflowBuilderWorkflow] = useState<AstWorkflow | null>(null);
   const workflowBuilderSnapshot = useRef<AstWorkflow | null>(null);
-  const [wbCollapsedSteps, setWbCollapsedSteps] = useState<Set<number>>(new Set());
-  const [wbConfirmDeleteIndex, setWbConfirmDeleteIndex] = useState<number | null>(null);
   const [showManualSetup, setShowManualSetup] = useState(false);
   const [manualSetupData, setManualSetupData] = useState<{ name: string; description: string; isPublic: boolean }>({ name: '', description: '', isPublic: false });
   const [manualBuilderWorkflow, setManualBuilderWorkflow] = useState<AstWorkflow | null>(null);
@@ -454,7 +452,6 @@ export const AssistantWorkflowBuilder: React.FC<WorkflowTemplateBuilderProps> = 
   };
 
   const handleOpenWorkflowBuilder = () => {
-    setWbCollapsedSteps(new Set());
     if (selectedWorkflowId) {
       // Edit existing workflow — use selectedWorkflow which has full steps loaded
       const snapshot = cloneDeep(selectedWorkflow);
@@ -590,7 +587,7 @@ export const AssistantWorkflowBuilder: React.FC<WorkflowTemplateBuilderProps> = 
                   title="Build your workflow step by step manually"
                 >
                   <IconEdit size={16} className="text-blue-600 dark:text-blue-400" />
-                  <span className="text-sm">Build Manually</span>
+                  <span className="text-sm">Build Workflow</span>
                 </button>
               </div>
             )}
@@ -684,6 +681,8 @@ export const AssistantWorkflowBuilder: React.FC<WorkflowTemplateBuilderProps> = 
           isTerminate={isTerminate}
           allowToolSelection={true}
           isNewStep={isNewStep}
+          allSteps={selectedWorkflow.template?.steps || []}
+          currentStepIndex={index}
         />
       </div>
     );
@@ -1042,8 +1041,8 @@ export const AssistantWorkflowBuilder: React.FC<WorkflowTemplateBuilderProps> = 
   const renderPreviewContent = () => {
     const nonTerminateSteps = selectedWorkflow.template?.steps.filter(s => s.tool !== 'terminate') ?? [];
     return (
-      <div className="flex-1 pl-4 overflow-y-auto">
-        <div className="mb-4 flex items-start justify-between gap-4">
+      <div className="flex-1 px-12 py-10 overflow-y-auto">
+        <div className="mb-10 flex items-start justify-between gap-4">
           <div className="min-w-0">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white truncate">
               {selectedWorkflow.name || 'Untitled Template'}
@@ -1061,7 +1060,7 @@ export const AssistantWorkflowBuilder: React.FC<WorkflowTemplateBuilderProps> = 
               className={`px-3 py-2 ${buttonStyle}`}
               onClick={() => setShowEditMenu(prev => !prev)}
               disabled={loadingSelectedWorkflow}
-              title="Edit this workflow template"
+              title="Edit this workflow"
             >
               <IconEdit size={16} className="text-gray-600 dark:text-gray-300" />
               Edit
@@ -1072,30 +1071,17 @@ export const AssistantWorkflowBuilder: React.FC<WorkflowTemplateBuilderProps> = 
                 <button
                   className="w-full px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
                   onClick={() => { setManualBuilderWorkflow(null); setForceVisualBuilderReset(false); setShowVisualBuilder(true); setShowEditMenu(false); }}
-                  title="Best for visual learners and complex workflows. Drag tools from a palette onto a canvas to build your workflow with instant preview."
+                  title="Drag tools onto the canvas to build your workflow visually"
                 >
                   <IconPuzzle size={16} className="text-blue-600 dark:text-blue-400" />
                   <span className="text-sm">Edit in Visual Builder</span>
                 </button>
                 <button
                   className="w-full px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
-                  onClick={() => { handleOpenWorkflowBuilder(); setShowEditMenu(false); }}
-                  title="Best for detailed control and complex configurations. Traditional form-based interface for precise step-by-step workflow creation."
+                  onClick={() => { setShowEditDetails(true); setShowEditMenu(false); }}
+                  title="Edit workflow name, description and settings"
                 >
-                  <IconEdit size={16} className="text-purple-600 dark:text-purple-400" />
-                  <span className="text-sm">Edit in Workflow Builder</span>
-                </button>
-                <div className="border-t border-gray-100 dark:border-gray-700 mx-2 my-1" />
-                <button
-                  className="w-full px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
-                  onClick={() => {
-                    setEditDetailsData({ name: selectedWorkflow.name, description: selectedWorkflow.description || '', isPublic: selectedWorkflow.isPublic || false });
-                    setShowEditDetails(true);
-                    setShowEditMenu(false);
-                  }}
-                  title="Edit the workflow name, description and accessibility setting"
-                >
-                  <IconInfoCircle size={16} className="text-gray-500 dark:text-gray-400" />
+                  <IconEdit size={16} className="text-gray-500 dark:text-gray-400" />
                   <span className="text-sm">Edit Details</span>
                 </button>
               </div>
@@ -1173,12 +1159,12 @@ export const AssistantWorkflowBuilder: React.FC<WorkflowTemplateBuilderProps> = 
 
                 <button
                   className="w-full p-4 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg text-left hover:border-gray-400 dark:hover:border-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700/30 transition-colors"
-                  onClick={() => { setManualSetupData({ name: '', description: '', isPublic: false }); setShowManualSetup(true); }}
+                  onClick={() => { setSelectedWorkflow(emptyTemplate(isBaseTemplate)); setManualBuilderWorkflow(null); setForceVisualBuilderReset(true); setShowVisualBuilder(true); }}
                   title="Build your workflow step by step manually"
                 >
                   <div className="flex items-center mb-2">
                     <IconEdit size={24} className="text-blue-600 dark:text-blue-400 mr-2" />
-                    <span className="font-medium text-gray-900 dark:text-white">Build Manually</span>
+                    <span className="font-medium text-gray-900 dark:text-white">Build Workflow</span>
                   </div>
                   <p className="text-sm text-gray-600 dark:text-gray-400">Best if you know what tools you need</p>
                 </button>
@@ -1265,265 +1251,6 @@ export const AssistantWorkflowBuilder: React.FC<WorkflowTemplateBuilderProps> = 
         availableAgentTools={availableAgentTools}
       />
 
-      {/* Workflow Builder Modal */}
-      {showWorkflowBuilder && workflowBuilderWorkflow && (() => {
-        const wbInnerHeight = Math.min(Math.max(window.innerHeight * 0.88, 600), window.innerHeight - 40);
-        const wbContentHeight = wbInnerHeight - 120;
-        return (
-          <Modal
-            title={
-              <span className="flex items-center gap-2">
-                <IconEdit size={20} className="text-purple-600 dark:text-purple-400" />
-                {workflowBuilderWorkflow.templateId ? `Edit — ${workflowBuilderWorkflow.name}` : `New Workflow — ${workflowBuilderWorkflow.name}`}
-              </span> as unknown as string
-            }
-            content={
-              <div className="flex flex-col" style={{ height: wbContentHeight }}>
-                {/* Scrollable content */}
-                <div className="flex-1 overflow-y-auto p-1">
-                  <div className="space-y-6">
-                    <div>
-                      <div className="flex items-center justify-between mb-4">
-                        <h3 className="text-lg font-medium text-gray-900 dark:text-white">Workflow Steps</h3>
-                        {(workflowBuilderWorkflow.template?.steps?.length ?? 0) > 1 && (
-                          <div className="flex gap-2">
-                            <button
-                              onClick={() => {
-                                const allIndices = new Set(workflowBuilderWorkflow.template?.steps?.map((_, i) => i) ?? []);
-                                setWbCollapsedSteps(allIndices);
-                              }}
-                              className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 underline transition-colors"
-                            >
-                              Collapse all
-                            </button>
-                            <span className="text-gray-300 dark:text-gray-600">|</span>
-                            <button
-                              onClick={() => setWbCollapsedSteps(new Set())}
-                              className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 underline transition-colors"
-                            >
-                              Expand all
-                            </button>
-                          </div>
-                        )}
-                      </div>
-                      <div className="space-y-3">
-                        {workflowBuilderWorkflow.template?.steps?.map((step, index) => {
-                          const isCollapsed = wbCollapsedSteps.has(index);
-                          const isTerminate = step.tool === 'terminate';
-                          const stepLabel = step.stepName || step.description || 'Untitled Step';
-                          return (
-                          <div key={index} className="border rounded-lg dark:border-gray-600 overflow-hidden">
-                            {/* Collapsible header */}
-                            <div
-                              className={`flex items-center gap-2 px-4 py-3 cursor-pointer select-none transition-colors ${
-                                isCollapsed
-                                  ? 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
-                                  : 'bg-gray-50 dark:bg-gray-700/30 border-b border-gray-200 dark:border-gray-600'
-                              }`}
-                              onClick={() => {
-                                setWbCollapsedSteps(prev => {
-                                  const next = new Set(prev);
-                                  next.has(index) ? next.delete(index) : next.add(index);
-                                  return next;
-                                });
-                              }}
-                            >
-                              <span className="text-gray-400 dark:text-gray-500 flex-shrink-0">
-                                {isCollapsed ? <IconChevronDown size={16} /> : <IconChevronUp size={16} />}
-                              </span>
-                              <span className={`text-sm font-semibold flex-shrink-0 ${isTerminate ? 'text-gray-400 dark:text-gray-500' : 'text-gray-700 dark:text-gray-200'}`}>
-                                {isTerminate ? 'Done (terminate)' : `Step ${index + 1}`}
-                              </span>
-                              {!isTerminate && stepLabel && (
-                                <span className="text-sm text-gray-500 dark:text-gray-400 truncate">— {stepLabel}</span>
-                              )}
-                              {/* Right-side group: tool badge + delete — always pushed to far right */}
-                              {!isTerminate && (
-                                <div className="ml-auto flex items-center gap-2 flex-shrink-0">
-                                  {step.tool ? (
-                                    <span className="text-xs px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
-                                      {step.tool}
-                                    </span>
-                                  ) : (
-                                    <span className="text-xs px-2 py-0.5 rounded-full bg-red-100 dark:bg-red-900/40 text-red-600 dark:text-red-400 italic">
-                                      no tool
-                                    </span>
-                                  )}
-                                  <button
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      setWbConfirmDeleteIndex(index);
-                                    }}
-                                    className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                                    title="Delete step"
-                                  >
-                                    <IconTrash size={15} />
-                                  </button>
-                                </div>
-                              )}
-                            </div>
-                            {/* Collapsible body */}
-                            {!isCollapsed && (
-                              <div className="p-4">
-                                <StepEditor
-                                  step={step}
-                                  stepIndex={index}
-                                  onStepChange={(updatedStep) => {
-                                    const updatedWorkflow = cloneDeep(workflowBuilderWorkflow);
-                                    if (updatedWorkflow.template?.steps) {
-                                      updatedWorkflow.template.steps[index] = updatedStep;
-                                      setWorkflowBuilderWorkflow(updatedWorkflow);
-                                    }
-                                  }}
-                                  availableApis={availableApis}
-                                  availableAgentTools={availableAgentTools}
-                                  isTerminate={isTerminate}
-                                  allowToolSelection={!isTerminate}
-                                  isNewStep={!isTerminate && (
-                                    !step.description?.trim() &&
-                                    !step.tool?.trim() &&
-                                    !step.instructions?.trim() &&
-                                    (!step.stepName?.trim() || step.stepName === 'New Step')
-                                  )}
-                                />
-                              </div>
-                            )}
-                          </div>
-                          );
-                        })}
-                        <button
-                          onClick={() => {
-                            const updatedWorkflow = cloneDeep(workflowBuilderWorkflow);
-                            if (!updatedWorkflow.template) updatedWorkflow.template = { steps: [] };
-                            const newStep: Step = { stepName: '', description: '', tool: '', instructions: '', args: {}, values: {} };
-                            const terminateIndex = updatedWorkflow.template.steps.findIndex(s => s.tool === 'terminate');
-                            if (terminateIndex !== -1) {
-                              updatedWorkflow.template.steps.splice(terminateIndex, 0, newStep);
-                            } else {
-                              updatedWorkflow.template.steps.push(newStep);
-                            }
-                            setWorkflowBuilderWorkflow(updatedWorkflow);
-                          }}
-                          className="w-full p-3 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg text-gray-600 dark:text-gray-400 hover:border-blue-500 dark:hover:border-blue-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors flex items-center justify-center gap-2"
-                        >
-                          <IconPlus size={20} />
-                          Add New Step
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Footer — matches Visual Builder */}
-                <div className="py-3 border-t border-gray-200 dark:border-gray-700 flex-shrink-0">
-                  <div className="flex justify-between items-center">
-                    <div className="flex items-center gap-3">
-                      {!workflowBuilderWorkflow.templateId && (
-                        <button
-                          onClick={() => {
-                            setShowWorkflowBuilder(false);
-                            setManualSetupData({ name: workflowBuilderWorkflow.name, description: workflowBuilderWorkflow.description || '', isPublic: workflowBuilderWorkflow.isPublic || false });
-                            setShowManualSetup(true);
-                          }}
-                          className="flex items-center gap-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 rounded-md transition-colors"
-                          title="Back to workflow setup"
-                        >
-                          <IconArrowDown size={16} className="rotate-90" />
-                          Back
-                        </button>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-4">
-                      <span className="text-sm text-gray-500 dark:text-gray-400">
-                        {(workflowBuilderWorkflow.template?.steps?.filter(s => s.tool !== 'terminate').length ?? 0)} steps configured
-                      </span>
-                      <button
-                        onClick={() => {
-                          // Restore snapshot — discard all unsaved changes
-                          if (workflowBuilderSnapshot.current) {
-                            setWorkflowBuilderWorkflow(cloneDeep(workflowBuilderSnapshot.current));
-                          }
-                          setShowWorkflowBuilder(false);
-                          setWorkflowBuilderWorkflow(null);
-                          workflowBuilderSnapshot.current = null;
-                        }}
-                        className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 rounded-md transition-colors"
-                      >
-                        Cancel
-                      </button>
-                      {(() => {
-                        const nonTerminateSteps = (workflowBuilderWorkflow.template?.steps ?? []).filter(s => s.tool !== 'terminate');
-                        const allStepsValid = nonTerminateSteps.every(s =>
-                          s.stepName?.trim() && s.description?.trim() && s.tool?.trim() && s.instructions?.trim()
-                        );
-                        const canSave = !!workflowBuilderWorkflow.name?.trim() && allStepsValid;
-                        return (
-                          <button
-                            onClick={() => handleSaveWorkflowFromBuilder(workflowBuilderWorkflow)}
-                            disabled={!canSave}
-                            className={`px-4 py-2 text-sm font-medium text-white rounded-md transition-colors shadow-sm ${
-                              !canSave ? 'bg-gray-400 cursor-not-allowed' : 'bg-blue-600 hover:bg-blue-700'
-                            }`}
-                          >
-                            Save Workflow
-                          </button>
-                        );
-                      })()}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            }
-            showCancel={false}
-            showSubmit={false}
-            disableClickOutside={true}
-            width={() => Math.max(window.innerWidth * 0.92, 1100)}
-            height={() => Math.min(Math.max(window.innerHeight * 0.88, 600), window.innerHeight - 40)}
-            onCancel={() => { setShowWorkflowBuilder(false); setWorkflowBuilderWorkflow(null); workflowBuilderSnapshot.current = null; }}
-            onSubmit={() => {}}
-          />
-        );
-      })()}
-      
-      {/* Step delete confirmation dialog */}
-      {wbConfirmDeleteIndex !== null && (
-        <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black bg-opacity-50">
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-600 p-6 max-w-sm w-full mx-4">
-            <h4 className="text-base font-semibold text-gray-900 dark:text-white mb-2">Delete Step</h4>
-            <p className="text-sm text-gray-600 dark:text-gray-400 mb-5">
-              Are you sure you want to delete{' '}
-              <span className="font-medium text-gray-900 dark:text-white">
-                &ldquo;Step {wbConfirmDeleteIndex + 1}{workflowBuilderWorkflow?.template?.steps?.[wbConfirmDeleteIndex]?.stepName ? ` — ${workflowBuilderWorkflow.template.steps[wbConfirmDeleteIndex].stepName}` : ''}&rdquo;
-              </span>? This cannot be undone.
-            </p>
-            <div className="flex gap-3 justify-end">
-              <button
-                onClick={() => setWbConfirmDeleteIndex(null)}
-                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 rounded-md transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={() => {
-                  const idx = wbConfirmDeleteIndex;
-                  const updatedWorkflow = cloneDeep(workflowBuilderWorkflow!);
-                  updatedWorkflow.template?.steps?.splice(idx, 1);
-                  setWorkflowBuilderWorkflow(updatedWorkflow);
-                  setWbCollapsedSteps(prev => {
-                    const next = new Set<number>();
-                    prev.forEach(i => { if (i < idx) next.add(i); else if (i > idx) next.add(i - 1); });
-                    return next;
-                  });
-                  setWbConfirmDeleteIndex(null);
-                }}
-                className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md transition-colors shadow-sm"
-              >
-                Delete
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
 
       {/* Delete confirmation dialog */}
       {confirmDeleteId && (() => {
@@ -1705,7 +1432,6 @@ export const AssistantWorkflowBuilder: React.FC<WorkflowTemplateBuilderProps> = 
                     onClick={() => {
                       const newWorkflow = { ...emptyTemplate(isBaseTemplate), name: manualSetupData.name, description: manualSetupData.description, isPublic: manualSetupData.isPublic };
                       workflowBuilderSnapshot.current = cloneDeep(newWorkflow);
-                      setWbCollapsedSteps(new Set());
                       setWorkflowBuilderWorkflow(newWorkflow);
                       setShowWorkflowBuilder(true);
                       setShowManualSetup(false);

--- a/components/AssistantWorkflows/StepEditor.tsx
+++ b/components/AssistantWorkflows/StepEditor.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useContext, useEffect } from 'react';
-import { Step } from '@/types/assistantWorkflows';
+import { Step, StepOutputAttribute } from '@/types/assistantWorkflows';
 import { OpDef } from '@/types/op';
 import { AgentTool } from '@/types/agentTools';
-import { IconPlus, IconTrash, IconChevronDown, IconChevronUp, IconEdit, IconEditOff, IconRobot, IconLoader2, IconSparkles, IconWand } from '@tabler/icons-react';
+import { IconPlus, IconTrash, IconChevronDown, IconChevronUp, IconEdit, IconEditOff, IconRobot, IconLoader2, IconSparkles, IconWand, IconPlugConnected } from '@tabler/icons-react';
 import Checkbox from '@/components/ReusableComponents/CheckBox';
 import { InputsMap } from '@/components/ReusableComponents/InputMap';
 import cloneDeep from 'lodash/cloneDeep';
@@ -21,6 +21,9 @@ interface StepEditorProps {
   isTerminate?: boolean;
   allowToolSelection?: boolean;
   isNewStep?: boolean; // Flag to indicate if this is a newly created step
+  // All steps in the workflow — used to show previous-step output references
+  allSteps?: Step[];
+  currentStepIndex?: number;
 }
 
 const StepEditor: React.FC<StepEditorProps> = ({
@@ -31,7 +34,9 @@ const StepEditor: React.FC<StepEditorProps> = ({
   availableAgentTools,
   isTerminate = false,
   allowToolSelection = true,
-  isNewStep = false
+  isNewStep = false,
+  allSteps,
+  currentStepIndex
 }) => {
   const { state: { chatEndpoint, defaultAccount, statsService }, getDefaultModel } = useContext(HomeContext);
   
@@ -39,6 +44,7 @@ const StepEditor: React.FC<StepEditorProps> = ({
   const [hoveredValueIndex, setHoveredValueIndex] = useState<string | null>(null);
   const [confirmDeleteValueKey, setConfirmDeleteValueKey] = useState<string | null>(null);
   const [toolPickerOpen, setToolPickerOpen] = useState(false);
+  const [openRefPickerKey, setOpenRefPickerKey] = useState<string | null>(null);
   
   // AI Generation state
   const [useAI, setUseAI] = useState(isNewStep && !isTerminate); // ON by default for new steps
@@ -388,6 +394,145 @@ const StepEditor: React.FC<StepEditorProps> = ({
         />
       </div>
 
+      {/* Skip Control */}
+      {!isTerminate && (
+        <div className="mb-4">
+          <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-neutral-200">
+            Skip Behaviour
+          </label>
+          <select
+            value={
+              step.allowSkip === false ? 'never' :
+              step.allowSkip === true  ? 'always' :
+              'default'
+            }
+            onChange={(e) => {
+              const v = e.target.value;
+              updateStep({
+                allowSkip: v === 'never' ? false : v === 'always' ? true : undefined
+              });
+            }}
+            className="w-full p-2 border border-gray-300 rounded-lg bg-white dark:bg-[#40414F] dark:border-neutral-600 text-gray-900 dark:text-white text-sm"
+          >
+            <option value="default">Default — AI decides whether to skip</option>
+            <option value="never">Never skip — always execute this step</option>
+            <option value="always">Always allow skip — AI may freely skip</option>
+          </select>
+        </div>
+      )}
+
+      {/* Auto-Repeat Step */}
+      {!isTerminate && (
+        <div className="mb-4 dark:text-white">
+          <Checkbox
+            id={`allow-repeat-${stepIndex}`}
+            label="Auto-Repeat Step"
+            checked={step.allowRepeat || false}
+            onChange={(checked) => updateStep({ allowRepeat: checked, maxRepeats: checked ? (step.maxRepeats ?? 1) : undefined })}
+          />
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 ml-6">
+            Re-run this step after each success (polling, pagination, batching). Stops when the tool returns <code className="text-xs bg-gray-100 dark:bg-gray-700 px-1 rounded">{"done: true"}</code> or <code className="text-xs bg-gray-100 dark:bg-gray-700 px-1 rounded">{"has_more: false"}</code>, or when max repeats is reached.
+          </p>
+          {step.allowRepeat && (
+            <div className="mt-2 ml-6 flex items-center gap-2">
+              <label className="text-xs text-gray-500 dark:text-gray-400">How many extra times to repeat</label>
+              <input
+                type="number"
+                min={1}
+                max={10}
+                value={step.maxRepeats ?? 1}
+                onChange={(e) => {
+                  const v = parseInt(e.target.value, 10);
+                  updateStep({ maxRepeats: isNaN(v) ? 1 : Math.min(10, Math.max(1, v)) });
+                }}
+                className="w-16 px-2 py-0.5 border border-gray-300 rounded bg-white dark:bg-[#40414F] dark:border-neutral-600 text-gray-900 dark:text-white text-sm"
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Output Attributes */}
+      {!isTerminate && (
+        <div className="mb-4">
+          <div className="flex justify-between items-center mb-2">
+            <div>
+              <label className="block text-sm font-medium dark:text-neutral-200">
+                Output Attributes
+              </label>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Declare what this step produces. Later steps can reference outputs via{' '}
+                <code className="bg-gray-100 dark:bg-gray-700 px-1 rounded text-xs">{'{{'}stepName.attributeName{'}}'}</code>
+              </p>
+            </div>
+            <button
+              onClick={() => {
+                const newOutput: StepOutputAttribute = { name: '', type: 'string' };
+                updateStep({ outputs: [...(step.outputs || []), newOutput] });
+              }}
+              className="flex items-center px-2 py-1 rounded text-sm bg-blue-600 text-white hover:bg-blue-700"
+            >
+              <IconPlus size={14} className="mr-1" />
+              Add Output
+            </button>
+          </div>
+          {(!step.outputs || step.outputs.length === 0) ? (
+            <div className="text-neutral-500 dark:text-neutral-400 text-sm">No outputs declared</div>
+          ) : (
+            step.outputs.map((output, outIdx) => (
+              <div key={outIdx} className="mb-2 grid grid-cols-[1fr_auto_1fr_auto] gap-2 items-center">
+                <input
+                  type="text"
+                  value={output.name}
+                  placeholder="Attribute name"
+                  onChange={(e) => {
+                    const updated = [...(step.outputs || [])];
+                    updated[outIdx] = { ...updated[outIdx], name: e.target.value };
+                    updateStep({ outputs: updated });
+                  }}
+                  className="p-2 border border-gray-300 rounded-lg bg-white dark:bg-[#40414F] dark:border-neutral-600 text-gray-900 dark:text-white text-sm"
+                />
+                <select
+                  value={output.type}
+                  onChange={(e) => {
+                    const updated = [...(step.outputs || [])];
+                    updated[outIdx] = { ...updated[outIdx], type: e.target.value as StepOutputAttribute['type'] };
+                    updateStep({ outputs: updated });
+                  }}
+                  className="p-2 border border-gray-300 rounded-lg bg-white dark:bg-[#40414F] dark:border-neutral-600 text-gray-900 dark:text-white text-sm"
+                >
+                  <option value="string">string</option>
+                  <option value="number">number</option>
+                  <option value="boolean">boolean</option>
+                  <option value="object">object</option>
+                  <option value="array">array</option>
+                </select>
+                <input
+                  type="text"
+                  value={output.description || ''}
+                  placeholder="Description (optional)"
+                  onChange={(e) => {
+                    const updated = [...(step.outputs || [])];
+                    updated[outIdx] = { ...updated[outIdx], description: e.target.value || undefined };
+                    updateStep({ outputs: updated });
+                  }}
+                  className="p-2 border border-gray-300 rounded-lg bg-white dark:bg-[#40414F] dark:border-neutral-600 text-gray-900 dark:text-white text-sm"
+                />
+                <button
+                  onClick={() => {
+                    const updated = (step.outputs || []).filter((_, i) => i !== outIdx);
+                    updateStep({ outputs: updated });
+                  }}
+                  className="p-1 text-red-600 dark:text-red-400 hover:opacity-60 rounded"
+                >
+                  <IconTrash size={16} />
+                </button>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+
       {/* Argument Instructions */}
       <div className="mb-4">
         <div className="flex justify-between items-center mb-2">
@@ -459,11 +604,38 @@ const StepEditor: React.FC<StepEditorProps> = ({
       </div>
 
       {/* Argument Values */}
+      {/* Build structured references from prior steps that have declared outputs ONLY */}
+      {(() => {
+        const idx = currentStepIndex ?? stepIndex;
+        const priorSteps = (allSteps ?? []).slice(0, idx);
+        // stepGroups: only steps with declared outputs
+        const stepGroups: { stepName: string; stepLabel: string; stepNum: number; outputs: { name: string; type: string; description?: string; refValue: string }[] }[] = [];
+        priorSteps.forEach((ps, i) => {
+          if (ps.outputs && ps.outputs.length > 0) {
+            const sName = ps.stepName || ps.tool || `step_${i + 1}`;
+            stepGroups.push({
+              stepName: sName,
+              stepLabel: ps.stepName || ps.tool || `Step ${i + 1}`,
+              stepNum: i + 1,
+              outputs: ps.outputs
+                .filter(o => o.name)
+                .map(o => ({ name: o.name, type: o.type || 'string', description: o.description, refValue: `{{${sName}.${o.name}}}` }))
+            });
+          }
+        });
+        const hasRefs = stepGroups.length > 0;
+
+        return (
       <div className="mb-4">
         <div className="flex justify-between items-center mb-2">
-          <label className="block text-sm font-medium dark:text-neutral-200">
-            Argument Values - Set fixed values for specific parameters (overrides AI decision-making)
-          </label>
+          <div>
+            <label className="block text-sm font-medium dark:text-neutral-200">
+              Argument Values
+            </label>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              Set a fixed value for a parameter — overrides AI.{hasRefs && <span className="ml-1 text-blue-500 dark:text-blue-400">Step outputs from previous steps are available to wire in.</span>}
+            </p>
+          </div>
           <div className="flex flex-col items-end">
             <button
               onClick={addArgumentValue}
@@ -494,8 +666,8 @@ const StepEditor: React.FC<StepEditorProps> = ({
           Object.entries(step.values || {})
             .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
             .map(([key, value], valueIndex) => (
-              <div 
-                key={valueIndex} 
+              <div
+                key={valueIndex}
                 className="flex mb-2 last:mb-0"
                 onMouseEnter={() => setHoveredValueIndex(`${stepIndex}-${valueIndex}`)}
                 onMouseLeave={() => setHoveredValueIndex(null)}
@@ -527,23 +699,24 @@ const StepEditor: React.FC<StepEditorProps> = ({
                         >
                           <option value={key}>{key}</option>
                           {/* Show available arguments that aren't already used */}
-                          {Object.keys(step.args || {}).filter(argKey => 
+                          {Object.keys(step.args || {}).filter(argKey =>
                             argKey !== key && !Object.keys(step.values || {}).includes(argKey)
                           ).map(argKey => (
                             <option key={argKey} value={argKey}>{argKey}</option>
                           ))}
                         </select>
                       </div>
-                      
-                      {/* Value Input */}
+
+                      {/* Value label */}
                       <label
                         className="border border-gray-400 dark:border-[#40414F] p-2 rounded-l text-[0.9rem] whitespace-nowrap text-center bg-gray-100 dark:bg-[#40414F] text-gray-700 dark:text-neutral-200"
                       >
                         Value
                       </label>
-                      <div className="w-full rounded-r border border-gray-500 dark:border-neutral-800 flex items-center bg-white dark:bg-[#40414F] text-gray-900 dark:text-neutral-100 shadow focus:outline-none">
+                      {/* Value input + reference picker inline on right */}
+                      <div className="w-full rounded-r border border-gray-500 dark:border-neutral-800 flex items-center bg-white dark:bg-[#40414F] shadow overflow-visible">
                         <input
-                          className="w-full border-0 px-4 py-1 bg-white dark:bg-[#40414F] text-gray-900 dark:text-neutral-100 focus:outline-none"
+                          className="flex-1 border-0 px-4 py-1.5 bg-transparent text-gray-900 dark:text-neutral-100 focus:outline-none min-w-0"
                           placeholder="Value content"
                           value={value}
                           onChange={(e) => {
@@ -552,11 +725,55 @@ const StepEditor: React.FC<StepEditorProps> = ({
                             updateStep({ values: newValues });
                           }}
                         />
+                        {/* Reference picker — sits on the right when prior steps have declared outputs */}
+                        {hasRefs && (
+                          <div className="relative flex-shrink-0 border-l border-gray-200 dark:border-neutral-600">
+                            <button
+                              type="button"
+                              onClick={() => setOpenRefPickerKey(openRefPickerKey === `${stepIndex}-${valueIndex}` ? null : `${stepIndex}-${valueIndex}`)}
+                              className="flex items-center gap-1 px-2.5 py-1.5 text-xs text-blue-600 dark:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors whitespace-nowrap"
+                            >
+                              <IconPlugConnected size={14} />
+                              Reference output from previous step
+                              <IconChevronDown size={11} className={`transition-transform ${openRefPickerKey === `${stepIndex}-${valueIndex}` ? 'rotate-180' : ''}`} />
+                            </button>
+                            {openRefPickerKey === `${stepIndex}-${valueIndex}` && (
+                              <div className="absolute right-0 top-full z-50 w-72 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-xl max-h-64 overflow-y-auto">
+                                {stepGroups.map(group => (
+                                  <div key={group.stepName}>
+                                    <div className="px-3 py-1.5 bg-gray-50 dark:bg-gray-700/60 border-b border-gray-100 dark:border-gray-600">
+                                      <span className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Step {group.stepNum} — {group.stepLabel}</span>
+                                    </div>
+                                    {group.outputs.map(out => (
+                                      <button
+                                        key={out.refValue}
+                                        type="button"
+                                        className="w-full flex items-center gap-3 px-4 py-2.5 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors text-left border-b border-gray-50 dark:border-gray-700/40 last:border-0"
+                                        onClick={() => {
+                                          const newValues = { ...step.values };
+                                          newValues[key] = out.refValue;
+                                          updateStep({ values: newValues });
+                                          setOpenRefPickerKey(null);
+                                        }}
+                                      >
+                                        <div className="flex-1 min-w-0">
+                                          <div className="text-sm font-medium text-gray-900 dark:text-white">{out.name}</div>
+                                          {out.description && <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{out.description}</div>}
+                                        </div>
+                                        <span className="flex-shrink-0 text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 font-mono">{out.type}</span>
+                                      </button>
+                                    ))}
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        )}
                       </div>
                     </div>
                   </div>
                 </div>
-                
+
                 <div className="w-[28px] flex items-center">
                   {hoveredValueIndex === `${stepIndex}-${valueIndex}` && (
                     <button
@@ -571,6 +788,8 @@ const StepEditor: React.FC<StepEditorProps> = ({
             ))
         )}
       </div>
+        );
+      })()}
 
       {confirmDeleteValueKey && (
         <div className="fixed inset-0 z-[10002] flex items-center justify-center bg-black bg-opacity-50">

--- a/components/AssistantWorkflows/ToolSelectorCore.tsx
+++ b/components/AssistantWorkflows/ToolSelectorCore.tsx
@@ -199,35 +199,31 @@ export const ToolSelectorCore: React.FC<ToolSelectorCoreProps> = ({
   );
 
   if (variant === 'panel') {
-    // Panel variant: Single scrollable area for everything
     return (
-      <div className={`flex-1 overflow-y-auto p-4 ${
-        isDarkMode ? 'bg-gray-50 dark:bg-gray-900/50' : 'bg-gray-50'
-      }`}>
-        <div className="space-y-4">
-          {/* Clear Search Button */}
-          {showClearSearch && (
-            <div className="flex justify-end">
-              <button
-                onClick={clearAllFilters}
-                className="px-3 py-1.5 text-xs font-medium text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md transition-colors"
-                title="Reset all filters to show all available tools"
-              >
-                Clear All
-              </button>
-            </div>
-          )}
-          
-          {/* Category Filter */}
+      <div className="flex flex-col flex-1 overflow-hidden bg-gray-50 dark:bg-gray-900/50">
+        {/* Filters — fixed at top */}
+        <div className="flex-shrink-0 p-4 space-y-3">
+          {/* Tool Type + Clear All on same row */}
           <div>
-            <label className="block text-xs font-semibold text-gray-800 dark:text-gray-200 mb-2">
-              Tool Type
-            </label>
+            <div className="flex items-center justify-between mb-1.5">
+              <label className="text-xs font-semibold text-gray-800 dark:text-gray-200">
+                Tool Type
+              </label>
+              {showClearSearch && (
+                <button
+                  onClick={clearAllFilters}
+                  className="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 underline transition-colors"
+                  title="Reset all filters"
+                >
+                  Clear All
+                </button>
+              )}
+            </div>
             <select
               value={selectedToolType}
               onChange={(e) => setSelectedToolType(e.target.value)}
               className="w-full px-3 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-              title="Filter tools by type (API integrations, agent tools, etc.)"
+              title="Filter tools by type"
             >
               {categories.map(category => (
                 <option key={category} value={category}>
@@ -236,25 +232,24 @@ export const ToolSelectorCore: React.FC<ToolSelectorCoreProps> = ({
               ))}
             </select>
           </div>
-          
-          {/* Search Filter */}
+
+          {/* Search */}
           <div>
-            <label className="block text-xs font-semibold text-gray-800 dark:text-gray-200 mb-2">
+            <label className="block text-xs font-semibold text-gray-800 dark:text-gray-200 mb-1.5">
               Search Tools
             </label>
             <div className="relative">
-              <IconSearch size={16} className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+              <IconSearch size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
               <input
                 type="text"
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 placeholder="Search tools..."
                 className="w-full pl-9 pr-3 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                title="Search by tool name, description, or tags"
               />
             </div>
           </div>
-          
+
           {/* Smart Tag Filter */}
           {showAdvancedFiltering && (
             <div title="Filter tools by functionality tags">
@@ -267,77 +262,57 @@ export const ToolSelectorCore: React.FC<ToolSelectorCoreProps> = ({
               />
             </div>
           )}
-          
-          {/* Selection Preview Section */}
+
+          {/* Selection Preview */}
           {allowMultiSelect && showSelectionPreview && (
-            <div className={`border-b p-4 ${
-              isDarkMode ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-gray-50'
+            <div className={`rounded-lg border p-3 ${
+              isDarkMode ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-white'
             }`}>
-              <h4 className={`text-sm font-semibold mb-3 flex items-center gap-2 ${
+              <h4 className={`text-xs font-semibold mb-2 flex items-center gap-2 ${
                 isDarkMode ? 'text-white' : 'text-gray-900'
               }`}>
-                <IconTool size={16} />
+                <IconTool size={14} />
                 Selected Tools ({selectedTools.length})
               </h4>
-              
               {selectedTools.length > 0 ? (
                 <div className="flex flex-wrap gap-2">
                   {selectedTools.map(tool => (
-                    <div
-                      key={tool.id}
-                      className={`flex items-center gap-2 px-3 py-2 rounded-lg ${
-                        isDarkMode 
-                          ? 'bg-blue-900/30 border border-blue-700 text-blue-200' 
-                          : 'bg-blue-100 border border-blue-300 text-blue-800'
-                      }`}
-                    >
-                      <div className="flex-shrink-0">
-                        {tool.icon}
-                      </div>
-                      <span className="text-sm font-medium">
-                        {snakeCaseToTitleCase(tool.name)}
-                      </span>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleRemoveTool(tool);
-                        }}
-                        className={`ml-1 hover:bg-opacity-20 hover:bg-red-500 rounded-full p-1 transition-colors ${
-                          isDarkMode ? 'text-blue-300 hover:text-red-300' : 'text-blue-600 hover:text-red-600'
-                        }`}
-                      >
-                        <IconX size={14} />
+                    <div key={tool.id} className={`flex items-center gap-1.5 px-2 py-1 rounded-md text-xs ${
+                      isDarkMode ? 'bg-blue-900/30 border border-blue-700 text-blue-200' : 'bg-blue-100 border border-blue-300 text-blue-800'
+                    }`}>
+                      <span className="font-medium">{snakeCaseToTitleCase(tool.name)}</span>
+                      <button onClick={(e) => { e.stopPropagation(); handleRemoveTool(tool); }} className="hover:text-red-500 transition-colors">
+                        <IconX size={12} />
                       </button>
                     </div>
                   ))}
                 </div>
               ) : (
-                <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
-                  No tools selected yet. Click on tools below to add them to your workflow.
-                </div>
+                <p className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>No tools selected yet.</p>
               )}
             </div>
           )}
-          
-          {/* Tool List */}
+
+          {/* Available Tools header */}
+          <div className="flex items-center gap-2 pt-1 border-t border-gray-200 dark:border-gray-700">
+            <IconTool size={14} className="text-gray-500 dark:text-gray-400" />
+            <span className="text-xs font-semibold text-gray-700 dark:text-gray-300">Available Tools</span>
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300 font-medium">
+              {filteredTools.length}
+            </span>
+          </div>
+        </div>
+
+        {/* Tool list — fills remaining height */}
+        <div className="flex-1 overflow-y-auto px-4 pb-4">
           <div className="space-y-2">
-            <div className="text-sm font-semibold text-gray-900 dark:text-white border-t border-gray-300 dark:border-gray-600 pt-4 pb-2 flex items-center gap-2">
-              <IconTool size={16} className="text-gray-600 dark:text-gray-400" />
-              Available Tools 
-              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 font-medium">
-                {filteredTools.length}
-              </span>
-            </div>
-            <div className="space-y-3 max-h-96 overflow-y-auto pb-4">
-              {filteredTools.map(tool => {
-                const isSelected = isToolSelected(tool);
-                const handleSelect = () => handleToolSelect(tool);
-                
-                return renderTool 
-                  ? renderTool(tool, handleSelect, isSelected)
-                  : defaultToolRenderer(tool, handleSelect, isSelected);
-              })}
-            </div>
+            {filteredTools.map(tool => {
+              const isSelected = isToolSelected(tool);
+              const handleSelect = () => handleToolSelect(tool);
+              return renderTool
+                ? renderTool(tool, handleSelect, isSelected)
+                : defaultToolRenderer(tool, handleSelect, isSelected);
+            })}
           </div>
         </div>
       </div>

--- a/components/AssistantWorkflows/VisualWorkflowBuilder.tsx
+++ b/components/AssistantWorkflows/VisualWorkflowBuilder.tsx
@@ -142,6 +142,7 @@ const ToolReplacementModal: React.FC<ToolReplacementModalProps> = ({
 interface StepCardProps {
   step: WorkflowStep;
   index: number;
+  isSelected: boolean;
   onEdit: (step: WorkflowStep) => void;
   onDelete: (stepId: string) => void;
   onMove: (stepId: string, direction: 'up' | 'down') => void;
@@ -151,8 +152,8 @@ interface StepCardProps {
   canMoveDown: boolean;
 }
 
-const StepCard: React.FC<StepCardProps> = ({ 
-  step, index, onEdit, onDelete, onMove, onToolReplace, onReorder, canMoveUp, canMoveDown 
+const StepCard: React.FC<StepCardProps> = ({
+  step, index, isSelected, onEdit, onDelete, onMove, onToolReplace, onReorder, canMoveUp, canMoveDown
 }) => {
   const [isHovered, setIsHovered] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -227,24 +228,24 @@ const StepCard: React.FC<StepCardProps> = ({
     <div
       draggable={step.tool !== 'terminate'}
       className={`
-        relative bg-white dark:bg-gray-800 border rounded-lg p-4 
-        transition-all duration-200 cursor-pointer
-        ${isHovered ? 'shadow-lg border-blue-300 dark:border-blue-600' : 'border-gray-200 dark:border-gray-700'}
-        ${step.tool === 'terminate' ? 'opacity-75' : ''}
+        relative bg-white dark:bg-gray-800 border-2 rounded-lg p-4
+        transition-all duration-200
+        ${step.tool === 'terminate' ? 'cursor-default opacity-60' : 'cursor-pointer'}
+        ${isSelected ? 'border-blue-500 dark:border-blue-400 shadow-md ring-2 ring-blue-200 dark:ring-blue-900' : isHovered ? 'shadow-lg border-blue-300 dark:border-blue-600' : 'border-gray-200 dark:border-gray-700'}
         ${isDragOver ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20' : ''}
         ${step.isEmpty ? 'border-orange-300 dark:border-orange-600' : ''}
         ${isDragging ? 'opacity-50 transform rotate-2' : ''}
         ${step.tool !== 'terminate' ? 'hover:shadow-md' : ''}
       `}
       style={segmentColor ? { borderLeftColor: segmentColor, borderLeftWidth: '4px' } : {}}
-      onMouseEnter={() => setIsHovered(true)}
+      onMouseEnter={() => { if (step.tool !== 'terminate') setIsHovered(true); }}
       onMouseLeave={() => setIsHovered(false)}
       onDragStart={handleDragStart}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
       onDragEnd={handleDragEnd}
-      onClick={() => onEdit(step)}
+      onClick={() => { if (step.tool !== 'terminate') onEdit(step); }}
     >
       {/* Drag Handle */}
       <div 
@@ -444,56 +445,47 @@ const VisualWorkflowBuilder: React.FC<VisualWorkflowBuilderProps> = ({
     };
   }, [isResizing]);
   
-  // Modal states
+  // State
   const [showToolPicker, setShowToolPicker] = useState(false);
   const [showToolReplacement, setShowToolReplacement] = useState(false);
-  const [showParameterConfig, setShowParameterConfig] = useState(false);
   const [toolPickerPosition, setToolPickerPosition] = useState<number>(0);
   const [replacementData, setReplacementData] = useState<{
     step: WorkflowStep;
     newTool: ToolItem;
   } | null>(null);
-  const [configStep, setConfigStep] = useState<{
-    step: WorkflowStep;
-    tool: ToolItem | null;
-    isNewStep?: boolean; // Flag to indicate if this is a newly created step
-  } | null>(null);
+  // Inline right-panel step editor
+  const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
+  const [selectedStepIsNew, setSelectedStepIsNew] = useState(false);
   const [draftStep, setDraftStep] = useState<WorkflowStep | null>(null);
-  
+
   // Tool items state
   const [toolItems, setToolItems] = useState<ToolItem[]>([]);
-  
+
   // Snapshot of workflowSteps taken when the modal opens — used to restore on Cancel
   const workflowStepsSnapshot = useRef<WorkflowStep[] | null>(null);
   const workflowSnapshot = useRef<AstWorkflow | null>(null);
 
-  // Ref for step editor modal scroll container
-  const stepEditorScrollRef = useRef<HTMLDivElement>(null);
-  
-  // Counter to force fresh StepEditor instance when modal reopens
-  const [stepEditorResetCounter, setStepEditorResetCounter] = useState(0);
   const [confirmDeleteStepId, setConfirmDeleteStepId] = useState<string | null>(null);
   
-  // Handle closing parameter config modal and resetting AI state
-  const handleCloseParameterConfig = () => {
-    // Commit the draft to workflowSteps
-    if (draftStep && configStep) {
+  // Discard draft changes — resets draftStep back to the last committed version
+  const handleDiscardStep = () => {
+    if (selectedStepId) {
+      const committed = workflowSteps.find(s => s.id === selectedStepId);
+      if (committed) {
+        setDraftStep({ ...committed });
+        toast('Changes discarded', { icon: '🗑️' });
+      }
+    }
+  };
+
+  // Close the panel — auto-saves any open draft first
+  const handleCloseStepEditor = () => {
+    if (draftStep) {
       setWorkflowSteps(prev => prev.map(s => s.id === draftStep.id ? draftStep : s));
     }
     setDraftStep(null);
-    setShowParameterConfig(false);
-    setStepEditorResetCounter(prev => prev + 1);
-  };
-
-  // Handle canceling parameter config — discard draft, remove step if new
-  const handleCancelParameterConfig = () => {
-    if (configStep?.isNewStep) {
-      setWorkflowSteps(prev => prev.filter(s => s.id !== configStep.step.id));
-    }
-    // Discard draft — no changes written
-    setDraftStep(null);
-    setShowParameterConfig(false);
-    setStepEditorResetCounter(prev => prev + 1);
+    setSelectedStepId(null);
+    setSelectedStepIsNew(false);
   };
 
   // Handle canceling the tool picker — removes the empty step that was added
@@ -610,19 +602,9 @@ const VisualWorkflowBuilder: React.FC<VisualWorkflowBuilderProps> = ({
       // Reset UI state as well
       setShowToolPicker(false);
       setShowToolReplacement(false);
-      setShowParameterConfig(false);
-      setConfigStep(null);
       setReplacementData(null);
     }
   }, [isOpen, initialWorkflow, forceReset]);
-  
-  // Reset step editor modal scroll position when opened
-  useEffect(() => {
-    if (showParameterConfig && stepEditorScrollRef.current) {
-      // Reset scroll to top when modal opens
-      stepEditorScrollRef.current.scrollTop = 0;
-    }
-  }, [showParameterConfig]);
   
   // Initialize tool items
   useEffect(() => {
@@ -658,6 +640,19 @@ const VisualWorkflowBuilder: React.FC<VisualWorkflowBuilderProps> = ({
   };
   
   
+  // Called when clicking a tool in the left panel — insert before terminate, no editor
+  const handlePanelToolClick = (tool: ToolItem) => {
+    const newStep = createStepFromTool(tool);
+    const newSteps = [...workflowSteps];
+    const terminateIndex = newSteps.findIndex(s => s.tool === 'terminate');
+    if (terminateIndex !== -1) {
+      newSteps.splice(terminateIndex, 0, newStep);
+    } else {
+      newSteps.push(newStep);
+    }
+    setWorkflowSteps(newSteps);
+  };
+
   const handleToolSelect = (tool: ToolItem) => {
     if (toolPickerPosition !== undefined) {
       const stepToUpdate = workflowSteps[toolPickerPosition];
@@ -669,15 +664,14 @@ const VisualWorkflowBuilder: React.FC<VisualWorkflowBuilderProps> = ({
         updatedStep.description = stepToUpdate.description || updatedStep.description;
         updatedStep.actionSegment = stepToUpdate.actionSegment;
         updatedStep.isEmpty = false;
-        
+
         const newSteps = [...workflowSteps];
         newSteps[toolPickerPosition] = updatedStep;
         setWorkflowSteps(newSteps);
-        
-        // Show parameter configuration modal
-        setConfigStep({ step: updatedStep, tool, isNewStep: true });
+
+        setSelectedStepId(updatedStep.id);
+        setSelectedStepIsNew(true);
         setDraftStep({ ...updatedStep });
-        setShowParameterConfig(true);
       }
     }
     setShowToolPicker(false);
@@ -695,25 +689,21 @@ const VisualWorkflowBuilder: React.FC<VisualWorkflowBuilderProps> = ({
   const handleConfirmReplacement = () => {
     if (replacementData) {
       const { step, newTool } = replacementData;
-      
-      // Create a clean step with the new tool, clearing all user-editable fields
+
       const updatedStep = createStepFromTool(newTool);
-      // Preserve only the essential step metadata
       updatedStep.id = step.id;
       updatedStep.position = step.position;
       updatedStep.actionSegment = step.actionSegment;
-      // Clear user fields (stepName, description, instructions, args, values are reset by createStepFromTool)
-      
+
       const newSteps = [...workflowSteps];
       const stepIndex = newSteps.findIndex(s => s.id === step.id);
       if (stepIndex !== -1) {
         newSteps[stepIndex] = updatedStep;
         setWorkflowSteps(newSteps);
-        
-        // Automatically open Step Editor for the user to configure the new tool
-        setConfigStep({ step: updatedStep, tool: newTool, isNewStep: false });
+
+        setSelectedStepId(updatedStep.id);
+        setSelectedStepIsNew(false);
         setDraftStep({ ...updatedStep });
-        setShowParameterConfig(true);
       }
     }
     setShowToolReplacement(false);
@@ -725,29 +715,18 @@ const VisualWorkflowBuilder: React.FC<VisualWorkflowBuilderProps> = ({
       setToolPickerPosition(step.position);
       setShowToolPicker(true);
     } else {
-      const tool = toolItems.find(t => t.name === step.tool) ?? null;
-      setConfigStep({ step, tool, isNewStep: false });
+      // Auto-save any open draft before switching to a different step
+      if (draftStep && selectedStepId && selectedStepId !== step.id) {
+        setWorkflowSteps(prev => prev.map(s => s.id === draftStep.id ? draftStep : s));
+      }
+      setSelectedStepId(step.id);
+      setSelectedStepIsNew(false);
       setDraftStep({ ...step });
-      setShowParameterConfig(true);
     }
   };
 
-  const handleStepChange = (updatedStep: Step, stepId: string) => {
-    // Only update the draft — do not write to workflowSteps until Save & Close
-    if (configStep && configStep.step.id === stepId) {
-      const baseDraft = draftStep ?? workflowSteps.find(s => s.id === stepId);
-      if (!baseDraft) return;
-      const updatedWorkflowStep = { ...baseDraft, ...updatedStep };
-      setDraftStep(updatedWorkflowStep);
-
-      // Keep configStep in sync so the modal title reflects changes
-      let updatedTool = configStep.tool;
-      if (updatedStep.tool && updatedStep.tool !== configStep.step.tool) {
-        const newToolItem = toolItems.find(t => t.name === updatedStep.tool);
-        if (newToolItem) updatedTool = newToolItem;
-      }
-      setConfigStep({ ...configStep, step: updatedWorkflowStep, tool: updatedTool });
-    }
+  const handleStepChange = (updatedStep: Step) => {
+    setDraftStep(prev => prev ? { ...prev, ...updatedStep } : null);
   };
 
   
@@ -834,39 +813,30 @@ const VisualWorkflowBuilder: React.FC<VisualWorkflowBuilderProps> = ({
 
   const handleToolDrop = (e: React.DragEvent) => {
     e.preventDefault();
-    
+
     const toolData = e.dataTransfer.getData('tool');
     if (toolData) {
       const serializableToolData = JSON.parse(toolData);
-      // Find the complete tool item from the available toolItems array
       const toolItem = toolItems.find(t => t.id === serializableToolData.id || t.name === serializableToolData.name);
-      
+
       if (toolItem) {
-        // Create a new step from the dropped tool
         const newStep = createStepFromTool(toolItem);
-        
-        // Find the terminate step and insert before it
         const terminateIndex = workflowSteps.findIndex(step => step.tool === 'terminate');
         const newSteps = [...workflowSteps];
-        
+
         if (terminateIndex !== -1) {
           newSteps.splice(terminateIndex, 0, newStep);
         } else {
           newSteps.push(newStep);
         }
-        
-        // Update positions
-        newSteps.forEach((step, index) => {
-          step.position = index;
-        });
-        
+
+        newSteps.forEach((step, index) => { step.position = index; });
         setWorkflowSteps(newSteps);
-        
-        // Show parameter configuration modal for the new step
+
         const stepPosition = terminateIndex !== -1 ? terminateIndex : newSteps.length - 1;
-        setConfigStep({ step: newSteps[stepPosition], tool: toolItem, isNewStep: true });
+        setSelectedStepId(newSteps[stepPosition].id);
+        setSelectedStepIsNew(true);
         setDraftStep({ ...newSteps[stepPosition] });
-        setShowParameterConfig(true);
       }
     }
   };
@@ -993,26 +963,45 @@ const VisualWorkflowBuilder: React.FC<VisualWorkflowBuilderProps> = ({
   
   if (!isOpen) return null;
 
-  const innerHeight = Math.min(Math.max(window.innerHeight * 0.88, 600), window.innerHeight - 40);
-  // Account for Modal's header (~64px) and footer (~56px)
-  const contentHeight = innerHeight - 120;
+
+  // Right-panel editor helpers
+  const editorStep = draftStep ?? (selectedStepId ? workflowSteps.find(s => s.id === selectedStepId) ?? null : null);
+  const editorStepIndex = editorStep ? workflowSteps.findIndex(s => s.id === editorStep.id) : -1;
+  const editorIsTerminate = editorStep?.tool === 'terminate';
+  const editorMissingFields = (!editorStep || editorIsTerminate) ? [] : [
+    !editorStep.stepName?.trim() && 'Step Name',
+    !editorStep.description?.trim() && 'Description',
+    !editorStep.tool?.trim() && 'Tool',
+    !editorStep.instructions?.trim() && 'Instructions',
+  ].filter(Boolean) as string[];
+  const editorIsValid = editorMissingFields.length === 0;
 
   const modalContent = (
-    <Modal
-      title={
-        <span className="flex items-center gap-2">
+    <div className="fixed inset-0 z-[9999] flex flex-col bg-white dark:bg-gray-900">
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 py-3 border-b border-gray-200 dark:border-gray-700 flex-shrink-0 bg-white dark:bg-gray-900">
+        <span className="flex items-center gap-2 text-base font-semibold text-gray-900 dark:text-white">
           <IconPuzzle size={20} className="text-blue-600 dark:text-blue-400" />
           Visual Workflow Builder{workflow.name ? ` — ${workflow.name}` : ''}
-        </span> as unknown as string
-      }
-      content={
-        <div className="flex flex-col" style={{ height: contentHeight }}>
-        {/* Content */}
+        </span>
+        <button
+          onClick={() => {
+            if (workflowStepsSnapshot.current) setWorkflowSteps(workflowStepsSnapshot.current.map(s => ({ ...s })));
+            if (workflowSnapshot.current) setWorkflow({ ...workflowSnapshot.current });
+            onClose();
+          }}
+          className="p-1.5 rounded-md text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        >
+          <IconX size={20} />
+        </button>
+      </div>
+      {/* Content */}
+        <div className="flex flex-col flex-1 overflow-hidden">
         <div className="flex flex-1 overflow-hidden">
           {/* Tool Palette - Left Panel */}
           <ToolSelectorPanel
             tools={availableTools}
-            onSelect={handleToolSelect}
+            onSelect={handlePanelToolClick}
             width={leftPanelWidth}
           />
           
@@ -1034,10 +1023,45 @@ const VisualWorkflowBuilder: React.FC<VisualWorkflowBuilderProps> = ({
             </div>
           </div>
           
-          {/* Workflow Canvas - Right Panel */}
-          <div className="flex-1 overflow-y-auto">
-            <div className="p-4 bg-gray-50 dark:bg-gray-900/50">
+          {/* Workflow Canvas - Center Panel */}
+          <div className={selectedStepId && editorStep ? 'w-120 flex-shrink-0 overflow-y-auto border-r border-gray-200 dark:border-gray-700' : 'flex-1 overflow-y-auto'}>
+            <div className="p-16 bg-gray-50 dark:bg-gray-900/50">
               <div className="max-w-xl mx-auto space-y-3">
+
+                {/* Workflow Metadata */}
+                <div className="mb-4 p-4 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 space-y-3">
+                  <div>
+                    <label className="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">
+                      Workflow Name <span className="text-red-500">*</span>
+                    </label>
+                    <input
+                      type="text"
+                      value={workflow.name}
+                      onChange={(e) => setWorkflow(prev => ({ ...prev, name: e.target.value }))}
+                      className="w-full p-2 text-sm border border-gray-300 rounded-lg bg-white dark:bg-[#40414F] dark:border-neutral-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      placeholder="Name your workflow"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Description</label>
+                    <textarea
+                      value={workflow.description || ''}
+                      onChange={(e) => setWorkflow(prev => ({ ...prev, description: e.target.value }))}
+                      rows={2}
+                      className="w-full p-2 text-sm border border-gray-300 rounded-lg bg-white dark:bg-[#40414F] dark:border-neutral-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+                      placeholder="Describe what this workflow does"
+                    />
+                  </div>
+                  <div className="dark:text-white">
+                    <Checkbox
+                      id="vb-isPublic"
+                      label="Accessible to any Amplify user"
+                      checked={workflow.isPublic || false}
+                      onChange={(checked) => setWorkflow(prev => ({ ...prev, isPublic: checked }))}
+                    />
+                  </div>
+                </div>
+
                 {/* Workflow Start */}
                 <div className="mb-4 text-center">
                   <div className="inline-flex items-center gap-2 px-3 py-1 bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200 rounded-full text-sm font-medium">
@@ -1093,6 +1117,7 @@ const VisualWorkflowBuilder: React.FC<VisualWorkflowBuilderProps> = ({
                           <StepCard
                             step={step}
                             index={index}
+                            isSelected={step.id === selectedStepId}
                             onEdit={handleStepEdit}
                             onDelete={handleStepDelete}
                             onMove={handleStepMove}
@@ -1120,6 +1145,55 @@ const VisualWorkflowBuilder: React.FC<VisualWorkflowBuilderProps> = ({
               
             </div>
           </div>
+          {/* Right Panel — Inline Step Editor */}
+          {selectedStepId && editorStep && (
+            <div className="flex-1 border-l border-gray-200 dark:border-gray-700 flex flex-col bg-white dark:bg-gray-800 overflow-hidden">
+              {/* Header */}
+              <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 flex items-center justify-between flex-shrink-0">
+                <h3 className="text-sm font-semibold text-gray-900 dark:text-white flex items-center gap-2 truncate min-w-0">
+                  <IconSettings size={16} className="flex-shrink-0 text-blue-500" />
+                  <span className="truncate">{(draftStep?.stepName || draftStep?.description) || (editorStep.stepName || editorStep.description) || 'Configure Step'}</span>
+                </h3>
+                <button
+                  onClick={handleCloseStepEditor}
+                  className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-500 dark:text-gray-400 flex-shrink-0 ml-2"
+                  title="Close"
+                >
+                  <IconX size={16} />
+                </button>
+              </div>
+
+              {/* Body */}
+              <div className="flex-1 overflow-y-auto p-4">
+                <StepEditor
+                  key={`right-panel-${editorStep.id}`}
+                  step={editorStep}
+                  stepIndex={editorStepIndex}
+                  onStepChange={handleStepChange}
+                  availableApis={availableApis}
+                  availableAgentTools={availableAgentTools}
+                  isTerminate={editorIsTerminate}
+                  allowToolSelection={true}
+                  isNewStep={selectedStepIsNew}
+                  allSteps={workflowSteps}
+                  currentStepIndex={editorStepIndex}
+                />
+              </div>
+
+              {/* Footer */}
+              <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between flex-shrink-0">
+                <span className="text-xs text-gray-400 dark:text-gray-500">Changes auto-saved when switching steps</span>
+                <button
+                  onClick={handleDiscardStep}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400 rounded-md transition-colors"
+                  title="Discard unsaved changes"
+                >
+                  <IconTrash size={14} />
+                  Discard
+                </button>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Footer */}
@@ -1199,24 +1273,7 @@ const VisualWorkflowBuilder: React.FC<VisualWorkflowBuilderProps> = ({
           </div>
         </div>
         </div>
-      }
-      onCancel={() => {
-        if (workflowStepsSnapshot.current) {
-          setWorkflowSteps(workflowStepsSnapshot.current.map(s => ({ ...s })));
-        }
-        if (workflowSnapshot.current) {
-          setWorkflow({ ...workflowSnapshot.current });
-        }
-        onClose();
-      }}
-      onSubmit={() => {}}
-      showCancel={false}
-      showSubmit={false}
-      disableClickOutside={true}
-      disableContentAnimation={false}
-      width={() => Math.max(window.innerWidth * 0.92, 1100)}
-      height={() => Math.min(Math.max(window.innerHeight * 0.88, 600), window.innerHeight - 40)}
-    />
+    </div>
   );
 
   const portals = (
@@ -1241,59 +1298,7 @@ const VisualWorkflowBuilder: React.FC<VisualWorkflowBuilderProps> = ({
         stepName={replacementData?.step.stepName || replacementData?.step.description || 'Step'}
       />
       
-      {configStep && (
-        <div className={`fixed inset-0 z-[10000] flex items-center justify-center bg-black bg-opacity-50 ${showParameterConfig ? '' : 'hidden'}`}>
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 max-w-4xl w-full mx-4 max-h-[80vh] flex flex-col">
-            <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                <IconSettings size={20} />
-                Configure Step: {configStep.step.stepName || configStep.step.description || 'Step'}
-              </h3>
-            </div>
-            <div className="flex-1 overflow-y-auto p-6" ref={stepEditorScrollRef}>
-              <StepEditor
-                key={`step-editor-${configStep.step.id}-${stepEditorResetCounter}`}
-                step={draftStep ?? configStep.step}
-                stepIndex={workflowSteps.findIndex(s => s.id === configStep.step.id)}
-                onStepChange={(updatedStep) => handleStepChange(updatedStep, configStep.step.id)}
-                availableApis={availableApis}
-                availableAgentTools={availableAgentTools}
-                isTerminate={configStep.step.tool === 'terminate'}
-                allowToolSelection={true}
-                isNewStep={configStep.isNewStep || false}
-              />
-            </div>
-            {(() => {
-              const currentStep = draftStep ?? configStep.step;
-              const isTerminateStep = currentStep.tool === 'terminate';
-              const missingFields = isTerminateStep ? [] : [
-                !currentStep.stepName?.trim() && 'Step Name',
-                !currentStep.description?.trim() && 'Description',
-                !currentStep.tool?.trim() && 'Tool',
-                !currentStep.instructions?.trim() && 'Instructions',
-              ].filter(Boolean) as string[];
-              const isValid = missingFields.length === 0;
-              return (
-                <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex items-center justify-end gap-3">
-                  <button
-                    onClick={handleCancelParameterConfig}
-                    className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-md"
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    onClick={handleCloseParameterConfig}
-                    disabled={!isValid}
-                    className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                  >
-                    Save & Close
-                  </button>
-                </div>
-              );
-            })()}
-          </div>
-        </div>
-      )}
+      {/* Step editing is now handled inline in the right panel — no floating modal */}
       {/* Step delete confirmation dialog */}
       {confirmDeleteStepId && (() => {
         const stepToDelete = workflowSteps.find(s => s.id === confirmDeleteStepId);

--- a/components/AssistantWorkflows/WorkflowGeneratorModal.tsx
+++ b/components/AssistantWorkflows/WorkflowGeneratorModal.tsx
@@ -139,10 +139,23 @@ Generate a workflow with the following JSON structure:
       "values": {
         "param_name": "Fixed value if known"
       },
-      "actionSegment": "optional_group_name"
+      "actionSegment": "optional_group_name",
+      "allowSkip": null,
+      "allowRepeat": false,
+      "maxRepeats": null,
+      "outputs": []
     }
   ]
 }
+
+Field explanations:
+- args: Parameter hints — the model is told how to determine these values but can override them
+- values: Hard-coded parameter values — the model cannot change these
+- actionSegment: Groups steps so users can toggle them on/off as a unit
+- allowSkip: null = LLM decides whether to skip, false = never skip this step, true = always allow skipping
+- allowRepeat: Set to true if this step should be re-run after each success (e.g. polling, paginated fetching). The step will stop repeating when its result contains {"done": true} or when maxRepeats is reached
+- maxRepeats: Max number of extra times to repeat the step (only relevant when allowRepeat is true). null means repeat once
+- outputs: Declare what this step produces so later steps can reference it via {{stepName.fieldName}}. Example: [{"name": "email_id", "type": "string", "description": "The ID of the created draft"}]
 
 Rules:
 - Each step must use a tool from the available tools list above
@@ -152,19 +165,12 @@ Rules:
 - Keep step names short, unique, and use underscores instead of spaces
 - Only use tools that were provided in the available tools list
 - If only the think tool is available, create a simple workflow with basic description and leave other tool names empty (empty string) so users can select tools manually later
-- Use "think" steps strategically when the agent needs to:
-  * Analyze or digest information from previous steps
-  * Understand context before making decisions
-  * Plan the approach for complex subsequent steps
-  * Process data or results to determine next actions
-  * Take a step back and evaluate progress
-- Think steps are NOT needed for every action - only when analysis/preparation is required
-- Action steps (API calls) should flow naturally when the task is straightforward
-- Example flow: API call → think (analyze results) → API call → think (plan next approach) → API call
-- For actionSegment usage:
-  * Core/essential steps that are required for the basic workflow should NOT have an actionSegment (leave undefined)
-  * Optional features, enhancements, or grouped functionality should use actionSegment
-  * Think steps that are essential should NOT have actionSegment
+- Use "think" steps strategically when the agent needs to analyze, plan, or process results between actions
+- Think steps are NOT needed for every action — only when analysis/preparation adds real value
+- Use allowRepeat for polling or paginated steps (e.g. fetch next page of results)
+- Use outputs to declare step results that later steps depend on; reference them in args/values as {{stepName.fieldName}}
+- Use allowSkip=false for critical steps that must always run
+- For actionSegment: core required steps get no segment; optional/grouped features get a segment name
 Generate ONLY the JSON, no additional text.`;
   };
 

--- a/types/assistantWorkflows.ts
+++ b/types/assistantWorkflows.ts
@@ -1,4 +1,10 @@
 
+export interface StepOutputAttribute {
+  name: string;
+  type: 'string' | 'number' | 'boolean' | 'object' | 'array';
+  description?: string;
+}
+
 export interface Step {
     description: string;
     tool: string; // ties to op
@@ -9,6 +15,17 @@ export interface Step {
     actionSegment?: string; // Groups steps by action, used to customize the workflow by linking steps to an action
     editableArgs?: string[]
     useAdvancedReasoning?: boolean;
+    // Output declarations — describe what this step produces so later steps can reference it
+    outputs?: StepOutputAttribute[];
+    // Repeat control — allow this step to be repeated (up to maxRepeats times); default false
+    allowRepeat?: boolean;
+    maxRepeats?: number;
+    // Skip control — explicitly forbid or allow the LLM skip heuristic
+    // undefined = default (LLM decides), true = always allow skip check, false = never skip
+    allowSkip?: boolean;
+    // Retry and timeout — surface the backend fields already in workflow_model.py
+    retries?: number;
+    timeout?: number; // seconds
   }
   
   export interface AstWorkflowTemplate {


### PR DESCRIPTION
…ntrols

Remove legacy "Workflow Builder" modal and its related state (wbCollapsedSteps, wbConfirmDeleteIndex); all editing now goes through the Visual Builder Rename "Build Manually" → "Build Workflow" and wire the card directly to the Visual Builder (bypassing the manual setup modal) Simplify the Edit dropdown to two actions: "Edit in Visual Builder" and "Edit Details" Add allSteps / currentStepIndex props to StepEditor to support cross-step output references Add Skip Behaviour select per step (default / never / always) Add Auto-Repeat Step checkbox with configurable maxRepeats (polling / pagination use-case) Add Output Attributes section so steps can declare named outputs referenceable by later steps Add Step Output References picker in argument fields to insert {{stepName.attr}} tokens Improve preview panel spacing (px-12 py-10, mb-10) for better readability