### PR TITLE
a11y: Fix WCAG accessibility issues #269-273

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ tests/chrome_profile/
 
 # open-notebook deployments
 deployment/
+
+# Synapse code intelligence index (auto-generated, do not commit)
+.synapse/

--- a/components/Chat/AttachFile.tsx
+++ b/components/Chat/AttachFile.tsx
@@ -251,6 +251,7 @@ export const AttachFile: FC<Props> = ({ id, onAttach, onUploadProgress, onSetMet
                 className="sr-only"
                 tabIndex={-1}
                 type="file"
+                aria-label="Attach file"
                 accept="*"
                 multiple
                 onChange={(e) => {

--- a/components/Chat/ModelSelect.tsx
+++ b/components/Chat/ModelSelect.tsx
@@ -161,7 +161,7 @@ export const ModelSelect: React.FC<Props> = ({
   const defaultModelLabel =  (name: string) => {
     return <>
       <span>{name}</span>
-      <span className="text-blue-500 ml-2 text-xs">{"(Default)"}</span>
+      <span className="text-blue-700 dark:text-blue-400 ml-2 text-xs">{"(Default)"}</span>
     </>
   }
   

--- a/components/ReusableComponents/ToggleOptionButtons.tsx
+++ b/components/ReusableComponents/ToggleOptionButtons.tsx
@@ -54,7 +54,7 @@ export const ToggleOptionButtons: React.FC<ToggleButtonGroupProps> = ({ options,
         className={`flex flex-row gap-2 py-1 px-2 text-[12px] rounded-full transition-all duration-300 focus:outline-none whitespace-nowrap ${
           isActive
             ? `bg-white dark:bg-[#1f1f29]  font-bold transform scale-105 ${activeColor || 'text-neutral-900 dark:text-neutral-100'}`
-            : 'bg-transparent text-neutral-500 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-[#31313f]'
+            : 'bg-transparent text-neutral-700 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-[#31313f]'
         }`}
         onClick={(e) => {
           e.preventDefault();

--- a/components/Sidebar/components/KebabMenu.tsx
+++ b/components/Sidebar/components/KebabMenu.tsx
@@ -526,6 +526,9 @@ interface Props {
                 <button
                     disabled={isSyncing}
                     id="promptHandler"
+                    aria-label="More options"
+                    aria-haspopup="true"
+                    aria-expanded={isMenuOpen}
                     className={`outline-none focus:outline-none p-0.5 transition-all duration-200 rounded-md ${isMenuOpen ? 'bg-neutral-200 dark:bg-[#343541]/90' : ''}`}
                     onClick={toggleDropdown}>
                     <IconDotsVertical size={20} className="flex-shrink-0 text-neutral-500 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-neutral-100 enhanced-icon transition-transform duration-300"/>

--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -1581,7 +1581,7 @@ const Home = ({
                     <meta name="description" content="ChatGPT but better." />
                     <meta
                         name="viewport"
-                        content="height=device-height ,width=device-width, initial-scale=1, user-scalable=no"
+                        content="height=device-height, width=device-width, initial-scale=1"
                     />
                     <link rel="icon" href="/favicon.ico" />
                 </Head>


### PR DESCRIPTION
## Summary

Fixes accessibility (WCAG) issues #269–#273 identified by karnsab via axe-core automated scans. 5 files, 10 lines changed.

### Changes

| Issue | WCAG | File | Fix |
|-------|------|------|-----|
| #269 | 1.4.4 Resize Text | `pages/api/home/home.tsx` | Removed `user-scalable=no` from viewport meta — allows mobile pinch-zoom |
| #270 | 4.1.2 Name/Role/Value | `components/Chat/AttachFile.tsx` | Added `aria-label="Attach file"` to hidden file input |
| #271 | 4.1.2 Name/Role/Value | — | Already compliant: `Modal` uses `aria-labelledby="modalTitle"` when `title` prop is set; `SettingDialog` passes `title="Settings"` ✅ |
| #272 | 4.1.2 Name/Role/Value | `components/Sidebar/components/KebabMenu.tsx` | Added `aria-label="More options"`, `aria-haspopup`, `aria-expanded` to `#promptHandler` button |
| #273 | 1.4.3 Contrast (Minimum) | `components/Chat/ModelSelect.tsx` + `components/ReusableComponents/ToggleOptionButtons.tsx` | `(Default)` label: `text-blue-500` → `text-blue-700 dark:text-blue-400`; inactive reasoning-level buttons: `text-neutral-500` → `text-neutral-700` |

## Test plan

- [ ] Mobile: pinch-zoom works (no longer blocked)
- [ ] axe-core: `meta-viewport` rule no longer fires
- [ ] axe-core: `label` rule on `#__attachFile` no longer fires
- [ ] axe-core: `aria-dialog-name` on Settings modal no longer fires
- [ ] axe-core: `button-name` on `#promptHandler` no longer fires
- [ ] axe-core: `color-contrast` on `(Default)` label and reasoning-level toggles no longer fires
- [ ] Visual: `(Default)` label readable in both light and dark mode
- [ ] Visual: Low/Medium/High/Off toggle buttons readable in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)