### PR TITLE
a11y: Add aria-label to import file input (WCAG 4.1.2)

### DIFF
--- a/components/Settings/Import.tsx
+++ b/components/Settings/Import.tsx
@@ -21,6 +21,7 @@ export const Import: FC<Props> = ({ onImport }) => {
         className="sr-only"
         tabIndex={-1}
         type="file"
+        aria-label="Import conversation JSON file"
         accept=".json"
         onChange={(e) => {
           if (!e.target.files?.length) return;


### PR DESCRIPTION
## Summary

Follow-up to #276 — fixes a remaining axe-core `label` violation found in both the Settings dialog and Sidebar states.

### Change

**File:** `components/Settings/Import.tsx`

The `#import-file` hidden file input had no accessible label (`aria-label`, `<label>`, or `title`). Added `aria-label="Import conversation JSON file"`.

```tsx
// Before
<input id="import-file" className="sr-only" tabIndex={-1} type="file" accept=".json" />

// After
<input id="import-file" className="sr-only" tabIndex={-1} type="file" aria-label="Import conversation JSON file" accept=".json" />
```

**WCAG criterion:** 4.1.2 Name, Role, Value (Level A)

## Test plan

- [ ] Run axe-core scan in Settings dialog state — `label` rule on `#import-file` no longer fires
- [ ] Run axe-core scan in Sidebar state — `label` rule on `#import-file` no longer fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)