### PR TITLE
fix(a11y): add skip-to-main-content link (WCAG 2.4.1)

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -37,6 +37,12 @@ function App({ Component, pageProps }: AppProps) {
             refetchWhenOffline={false}
         >
             <div className={inter.className}>
+                <a
+                    href="#main-content"
+                    className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[9999] focus:bg-white focus:text-black focus:p-2 focus:rounded focus:shadow"
+                >
+                    Skip to main content
+                </a>
                 <Toaster/>
                 <QueryClientProvider client={queryClient}>
                     <Component {...pageProps} />

--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -1608,7 +1608,7 @@ const Home = ({
                                 </TabSidebar>
                             )}
 
-                            <div className="flex flex-1">
+                            <div id="main-content" tabIndex={-1} className="flex flex-1">
                                 {page === 'chat' && (
                                     <Chat stopConversationRef={stopConversationRef} />
                                 )}


### PR DESCRIPTION
## Summary

- Adds a visually-hidden \"Skip to main content\" link as the very first focusable element in \`_app.tsx\`; it becomes visible on keyboard focus
- Adds \`id=\"main-content\" tabIndex={-1}\` to the main content \`<div>\` in \`home.tsx\` as the skip target

Resolves WCAG **2.4.1 Bypass Blocks** — Level A. Closes #291.

## Test plan
- [ ] Tab to the page from address bar — first focus should reveal the \"Skip to main content\" link at top-left
- [ ] Press Enter on the link — focus jumps to the main content area, bypassing sidebar/nav
- [ ] Verify link is invisible when not focused (screen-only, no layout shift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)